### PR TITLE
Add matlab-digital-filter-design skill

### DIFF
--- a/skills/matlab-digital-filter-design/SKILL.md
+++ b/skills/matlab-digital-filter-design/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: matlab-digital-filter-design
+description: Designs and validates digital filters in MATLAB. Use when cleaning up noisy signals, removing interference, filtering signals, designing FIR/IIR filters (lowpass/highpass/bandpass/bandstop/notch), or comparing filters in Filter Analyzer.
+---
+
+# MATLAB Digital Filter Design Expert
+
+You design, implement, and validate digital filters in MATLAB (Signal Processing Toolbox + DSP System Toolbox). You help users choose the right architecture (single-stage vs efficient alternatives), generate correct code, and verify the result with plots + numbers.
+
+## Must-follow
+- **Read INDEX.md**
+- **Always write to .m files.** Never put multi-line MATLAB code directly in `evaluate_matlab_code`. Write to a `.m` file, run with `run_matlab_file`, edit on error. This saves tokens on error recovery.
+- **Preflight before ANY MATLAB call.** Before calling ANY function listed in INDEX.md — via `evaluate_matlab_code`, `run_matlab_file`, or `.m` file — read the required cards first. State `Preflight: [cards]` at top of response. No exceptions.
+- **Do not guess key requirements.** If *Mode* (streaming vs offline) or *Phase requirement* is not stated, **ask**.  
+  You may analyze the signal first (spectrum, peaks, bandwidth), but you must not silently commit to `filtfilt()` or a linear‑phase design without the user’s intent.
+- **No Hz designs without Fs.** If `Fs` is unknown, **STOP and ask** (unless the user explicitly wants normalized frequency).
+- **Always pin the sample rate.**
+  - `designfilt(..., SampleRate=Fs)`
+  - `freqz(d, [], Fs)` / `grpdelay(d, [], Fs)` (plot in **Hz**)
+- **IIR stability:** prefer **SOS/CTF** forms (avoid high‑order `[b,a]` polynomials).
+
+### MATLAB Code/Function Call Best Practise
+- Write code to a `.m` file first, then run with `run_matlab_file`
+- If errors occur, edit the file and rerun — don't put all code inline in tool calls
+
+1. List MATLAB functions you'll call
+2. Check `knowledge/INDEX.md` for each (function-level + task-level tables)
+3. Read required cards
+4. State at response top:
+   ```
+   Preflight: cards/filter-analyzer.md, cards/designfilt.md
+   ```
+   or `Preflight: none required (no indexed functions)`
+
+## Planning workflow (phases)
+
+### Phase 1: Signal Analysis
+- Use MCP to analyze input data (spectrum, signal length, interference location, etc.)
+- Compute `trans_pct` and identify interference characteristics
+- This gives accurate estimates instead of guesses
+
+### Phase 2: Clarify Intent (before any overview or comparison)
+**After signal analysis, ask Mode + Phase if not stated:**
+- **Mode**: streaming (causal) | offline (batch)
+- **Phase**: zero-phase | linear-phase | don't-care
+
+Use `AskUserQuestion` with clear descriptions:
+- Streaming = real-time, sample-by-sample, must be causal
+- Offline = batch processing, can use `filtfilt()` for zero-phase
+- Zero-phase = no time shift, preserves transient shape (offline only)
+- Linear-phase = constant group delay, works both modes
+- Don't-care = minimize compute, phase distortion acceptable
+
+**Wait for answer before showing any approach comparison or overview.**
+
+### Phase 3: Architecture Selection (show only viable options)
+- Open `efficient-filtering.md` if `trans_pct < 2%`
+- Show **only viable candidates** given Mode + Phase constraints
+- Explicitly state excluded families with one-line reason
+- Use Filter Analyzer for visual comparison
+
+---
+
+## Design intake checklist
+
+### Checklist A: Required signal + frequency spec (cannot proceed without)
+
+- [ ] `Fs` (Hz)
+- [ ] Response type: lowpass / highpass / bandpass / bandstop / notch
+- [ ] Edge frequencies in Hz
+  - low/high: `Fpass`, `Fstop`
+  - bandpass/bandstop: `Fpass1`, `Fstop1`, `Fpass2`, `Fstop2`
+  - notch: center `F0` (+ bandwidth or Q)
+
+If any item is missing → **ask**.
+
+### Checklist B: Required intent for architecture choice (must ask if unknown)
+
+- [ ] **Mode**: streaming (causal) | offline (batch)
+- [ ] **Phase**: zero‑phase | linear‑phase | don’t‑care
+- [ ] **Magnitude constraints** (make explicit):
+  - `Rp_dB` passband ripple (default **1 dB**)
+  - `Rs_dB` stopband attenuation (default **60 dB**)
+  - for asymmetric band specs: allow `Rs1_dB`, `Rs2_dB`
+
+If Mode or Phase is unknown: ask **1–2** clarifying questions and stop.  
+Do **not** assume “offline” or “zero‑phase”.
+
+### Standard spec block (always include)
+
+```text
+Fs = ___ Hz
+Response = lowpass | highpass | bandpass | bandstop | notch
+Edges (Hz) = ...
+Magnitude = Rp = ___ dB, Rs = ___ dB  (or Rs1/Rs2)
+Mode = streaming | offline
+Phase = zero-phase | linear-phase | don't-care
+Constraints = latency/CPU/memory/fixed-point (if any)
+```
+
+---
+
+## Architecture checkpoint
+
+Compute these and state them before finalizing an approach:
+
+- `trans_bw = Fstop - Fpass`
+- `trans_pct = 100 * trans_bw / Fs`
+- `M_max = floor(Fs/(2*Fstop))` (only meaningful for lowpass-based multirate ideas)
+
+**Decision rule**
+
+- `trans_pct > 5%` → single‑stage FIR or IIR is usually fine
+- `2% ≤ trans_pct ≤ 5%` → single‑stage is possible; mention efficient alternatives if cost/latency matters
+- `trans_pct < 2%` → **STOP and do a narrow‑transition comparison**
+  Open `knowledge/cards/efficient-filtering.md`.
+
+**Important:** for `trans_pct < 2%`, do **not** blindly show all four families.  
+Select and present only the **viable** candidates given Mode + Phase, and explicitly mark excluded families (with a one‑line reason).
+
+---
+
+## Design + verify workflow
+
+1. **Feasibility / order sanity check**
+   - Default: let `designfilt` choose minimum order from `Rp/Rs`, then query `filtord(d)`.
+   - Optional (especially for narrow transitions): use `kaiserord` / `firpmord` to estimate FIR length for planning (not as “the truth”).
+
+2. **Design candidates**
+   - Prefer `designfilt()` with explicit `Rp/Rs` and `SampleRate=Fs`.
+   - Streaming IIR: prefer `SystemObject=true` (returns `dsp.SOSFilter`) for stable, stateful filtering.
+   - Offline zero‑phase: `filtfilt()` is allowed, but you must state:
+     - forward‑backward filtering **squares magnitude** (≈ doubles dB attenuation) and effectively doubles order.
+
+3. **Compare visually when there's a choice**
+   - **Use `filterAnalyzer()`** for comparing ≥2 designs — do not write custom freqz/grpdelay plots
+   - Open `knowledge/cards/filter-analyzer.md` first
+   - Minimum displays: magnitude + group delay (add impulse response when latency is a concern)
+
+4. **Verify with numbers (not just plots)**
+   - Worst‑case passband ripple and stopband attenuation vs spec.
+   - For `filtfilt()`, verify the **effective** response (magnitude squared).
+
+5. **Deliver the output**
+   - Specs recap
+   - Derived metrics (`trans_pct`, order/taps, MPIS if relevant)
+   - Chosen architecture + why
+   - MATLAB code
+   - Verification snippet + results
+   - Implementation form (digitalFilter vs System object, SOS/CTF export)
+
+That’s the whole job: make the workflow predictable, and make the assumptions impossible to miss.

--- a/skills/matlab-digital-filter-design/knowledge/INDEX.md
+++ b/skills/matlab-digital-filter-design/knowledge/INDEX.md
@@ -1,0 +1,60 @@
+# Knowledge Index
+
+**Cards contain critical gotchas. You MUST read the relevant card before writing any code that uses the functions listed below. Skipping cards causes errors.**
+
+- **Cards**: Short, task-focused. Read before calling specific functions.
+- **Guides**: Deep reference. Read when you need full context.
+
+---
+
+## Function-Level Routing (read the card or you WILL hit errors)
+
+| Function / Pattern | Card to read |
+|--------------------|--------------|
+| `designfilt(...)` any response | `cards/designfilt.md` |
+| `iirnotch(...)`, `iircomb(...)` | `cards/designfilt.md` |
+| `ifir(...)`, `design(..., 'ifir')` | `cards/multistage-ifir.md` |
+| `filterAnalyzer(...)` | `cards/filter-analyzer.md` |
+| `dsp.FIRDecimator`, `dsp.FIRInterpolator` | `cards/multirate-streaming.md` |
+| `resample(...)` for filtering | `cards/multirate-offline.md` |
+| High-order IIR (>8), long FIR (>100 taps), `freqz`/`grpdelay` | `cards/general-iir-fir.md` |
+
+---
+
+## Task-Level Routing
+
+| Trigger / task | Card to read | Guide (if needed) |
+|----------------|--------------|-------------------|
+| `trans_pct < 2%` or "very sharp / tight transition" | `cards/efficient-filtering.md` | `efficient-filtering.md` |
+| Cost comparison / "fastest/cheapest" / MPIS | `cards/efficient-filtering.md` | `efficient-filtering.md` |
+| Using **Filter Analyzer** (`filterAnalyzer`, session mgmt, overlays) | `cards/filter-analyzer.md` | `filter-analyzer.md` |
+| **Multirate OFFLINE** (rate change + zero-phase) | `cards/multirate-offline.md` | `multirate.md` |
+| **Multirate STREAMING** (polyphase System objects) | `cards/multirate-streaming.md` | `multirate.md` |
+| **Constant-rate multistage FIR** (IFIR method) | `cards/multistage-ifir.md` | `multistage-ifir.md` |
+
+---
+
+## Card Summary
+
+| Card | Purpose | ~Lines |
+|------|---------|--------|
+| `cards/designfilt.md` | Response types, params, gotchas | ~110 |
+| `cards/general-iir-fir.md` | High-order IIR, long FIR, freqz, filtfilt | ~80 |
+| `cards/efficient-filtering.md` | Narrow transitions, MPIS comparison | ~130 |
+| `cards/filter-analyzer.md` | Filter Analyzer API | ~100 |
+| `cards/multirate-offline.md` | Offline zero-phase with rate change | ~60 |
+| `cards/multirate-streaming.md` | Streaming polyphase pipelines | ~75 |
+| `cards/multistage-ifir.md` | IFIR at constant rate | ~95 |
+
+---
+
+## Guides (deep reference, rarely needed full)
+
+| Guide | Content | ~Lines |
+|-------|---------|--------|
+| `patterns.md` | Streaming wrappers, advanced patterns | ~400 |
+| `best-practices.md` | Methodology, validation flow | ~375 |
+| `filter-analyzer.md` | Full Filter Analyzer reference | ~515 |
+| `multirate.md` | Complete multirate theory + examples | ~405 |
+| `efficient-filtering.md` | Deep dive on narrow transitions | ~375 |
+| `multistage-ifir.md` | IFIR theory and variants | ~290 |

--- a/skills/matlab-digital-filter-design/knowledge/best-practices.md
+++ b/skills/matlab-digital-filter-design/knowledge/best-practices.md
@@ -1,0 +1,373 @@
+# Filter Design Best Practices
+
+Guidelines for robust filter design, validation workflows, and professional interactions. Consult this file when you need guidance on methodology and approach.
+
+## Table of Contents
+- [Core Principles](#core-principles)
+- [Provide Complete Solutions](#provide-complete-solutions)
+- [Documentation Usage Strategy](#documentation-usage-strategy)
+- [Common Tasks Reference](#common-tasks-reference)
+- [Example Interaction Pattern](#example-interaction-pattern)
+- [Validation Workflow](#validation-workflow)
+- [Architecture Decision Workflow](#architecture-decision-workflow)
+- [Streaming vs Offline](#streaming-vs-offline)
+- [Performance Optimization](#performance-optimization)
+- [Quick Lookup](#quick-lookup)
+
+---
+
+## Core Principles
+
+### Always Consider
+
+1. **Sample Rate Implications**
+   - Frequency specifications are relative to Fs/2 (Nyquist)
+   - Narrow transition bands (< 2% of Fs) require special handling
+   - Plot in Hz for clarity: `freqz(d, [], Fs)`
+
+2. **Filter Order vs Performance Trade-offs**
+   - Higher order = sharper cutoff but more computation
+   - IIR = fewer coefficients but non-linear phase
+   - FIR = linear phase but longer filters
+
+3. **Computational Efficiency for Real-Time**
+   - Prefer IIR for streaming with sharp cutoff
+   - Use multistage for narrow transition bands
+   - Consider `fftfilt()` for long FIR (> 100 taps)
+
+4. **Numerical Stability for IIR**
+   - Always use SOS or CTF form (not `[b,a]`)
+   - Use `designfilt()` which handles stability internally
+   - For high-order IIR (> 8), verify pole locations
+
+---
+
+## Provide Complete Solutions
+
+Every filter design response should include:
+
+### 1. Design Code
+```matlab
+d = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+```
+
+### 2. Visualization Code
+```matlab
+figure;
+freqz(d, [], Fs);
+grid on;
+title('Filter Response');
+```
+
+### 3. Parameter Explanation
+- Why this filter type was chosen
+- Trade-offs considered
+- Key specifications achieved
+
+### 4. Validation Steps
+- How to verify the design meets specs
+- Test signal suggestions
+- Performance metrics to check
+
+---
+
+## Documentation Usage Strategy
+
+### Start Broad, Drill Down
+
+1. **First**: Check `docs/INDEX.md` for file summaries
+2. **Overview**: Read `signal_filter-design.md` for concepts
+3. **Details**: Drill into `ref_designfilt.md` for exact syntax
+4. **Examples**: Check `examples/` for complete workflows
+
+### Reference During Design
+
+- **Verify syntax** against official docs before executing
+- **Check examples** in documentation for similar problems
+- **Confirm parameters** for edge cases (bandpass, notch, etc.)
+
+---
+
+## Common Tasks Reference
+
+### Task: Design Lowpass Filter
+
+1. **Check quick-reference.md** for parameter templates
+2. **Read relevant section** from `ref_designfilt.md`
+3. **Generate MATLAB code** using `designfilt()`
+4. **Test if MCP available** by running code
+5. **Provide visualization** code for frequency response
+
+### Task: Choose Design Method
+
+**Consult** `signal_filter-design.md` for:
+- Design method comparison
+- When to use each approach
+- Trade-offs between methods
+
+**Reference** `ref_designfilt.md` for:
+- Available methods per filter type
+- Method-specific parameters
+- Examples using each method
+
+### Task: Analyze Existing Filter
+
+1. **Guide user** to use Filter Analyzer app
+2. **Reference** `ref_filteranalyzer-app.md` for:
+   - How to import filters
+   - Available analysis types
+   - Interpretation of results
+
+### Task: Apply Filter to Data
+
+1. **Determine requirements**:
+   - Need zero phase? → Use `filtfilt()`
+   - Long FIR filter? → Consider `fftfilt()`
+   - Streaming/real-time? → Use `dsp.SOSFilter`
+   - Standard application? → Use `filter()`
+
+2. **Reference appropriate documentation**:
+   - `ref_filtfilt.md` for zero-phase requirements
+   - `ref_fftfilt.md` for performance optimization
+   - `ref_filter.md` for state management
+
+---
+
+## Example Interaction Pattern
+
+**User Request**: "I need a bandpass filter for 50-100 Hz signal at 1000 Hz sampling rate"
+
+**Your Response Pattern**:
+
+### Step 1: Clarify Requirements
+Ask about:
+- FIR or IIR preference?
+- Phase requirements (linear, zero, minimum)?
+- Stopband attenuation needed?
+
+### Step 2: Read Documentation
+Check `ref_designfilt.md` for bandpass filter syntax
+
+### Step 3: Recommend Approach
+Suggest FIR equiripple (linear phase) or IIR Butterworth (minimum order)
+
+### Step 4: Generate Code
+Provide complete `designfilt()` code with all parameters
+
+### Step 5: Test (if MCP available)
+Execute and show frequency response
+
+### Step 6: Guide Application
+Explain how to apply with `filter()` or `filtfilt()`
+
+---
+
+## Validation Workflow
+
+### Pre-Application Checks
+
+```matlab
+% 1) Order (MATLAB's actual order)
+fprintf("Filter order: %d\n", filtord(d));
+
+% 2) Frequency response (Hz-aware)
+Nfft = 8192;
+[h, f] = freqz(d, Nfft, Fs);
+mag_dB = 20*log10(abs(h) + eps);
+
+% 3) If the final application is filtfilt(d,x), verify the *effective* response
+use_filtfilt = false;  % set true if you will apply filtfilt()
+if use_filtfilt
+    mag_dB = 2*mag_dB;  % |H|^2 -> dB doubles
+end
+
+% 4) Build pass/stop masks by RESPONSE TYPE
+responseType = "lowpass";  % "highpass" | "bandpass" | "bandstop"
+
+switch responseType
+    case "lowpass"
+        pass = f <= Fpass;
+        stop = f >= Fstop;
+    case "highpass"
+        pass = f >= Fpass;
+        stop = f <= Fstop;
+    case "bandpass"
+        pass = (f >= Fpass1) & (f <= Fpass2);
+        stop = (f <= Fstop1) | (f >= Fstop2);
+    case "bandstop"
+        pass = (f <= Fpass1) | (f >= Fpass2);
+        stop = (f >= Fstop1) & (f <= Fstop2);
+end
+
+% 5) Measured specs (worst-case)
+Rp_meas_dB = max(mag_dB(pass)) - min(mag_dB(pass));
+Rs_meas_dB = -max(mag_dB(stop));
+
+fprintf("Measured ripple: %.3f dB (spec %.3f dB)\n", Rp_meas_dB, Rp);
+fprintf("Measured stopband attenuation: %.1f dB (spec %.1f dB)\n", Rs_meas_dB, Rs);
+
+% 6) Plot (optional but recommended)
+figure; plot(f, mag_dB); grid on;
+xlabel("Frequency (Hz)"); ylabel("Magnitude (dB)");
+title("Magnitude Response (verified in Hz)");
+```
+
+### Post-Filtering Checks
+
+```matlab
+% 1. Visual comparison
+figure;
+plot(t, x, 'b', t, y, 'r');
+legend('Original', 'Filtered');
+
+% 2. Spectrum comparison
+figure;
+pwelch(x, [], [], [], Fs); hold on;
+pwelch(y, [], [], [], Fs);
+legend('Original', 'Filtered');
+
+% 3. SNR improvement (if ground truth available)
+snr_before = 10*log10(sum(clean.^2) / sum((noisy - clean).^2));
+snr_after = 10*log10(sum(clean.^2) / sum((filtered - clean).^2));
+fprintf('SNR Improvement: %.1f dB\n', snr_after - snr_before);
+```
+
+---
+
+## Architecture Decision Workflow
+
+### Pre-Design Check (MANDATORY)
+
+For EVERY filter design, calculate:
+
+```matlab
+% Transition width (Δf) should match the RESPONSE TYPE.
+% Use the *constraining* transition (smallest transition band) in Hz.
+%
+% lowpass:   Δf = Fstop - Fpass
+% highpass:  Δf = Fpass - Fstop
+% bandpass:  Δf = min(Fpass1 - Fstop1, Fstop2 - Fpass2)
+% bandstop:  Δf = min(Fstop1 - Fpass1, Fpass2 - Fstop2)
+
+delta_f = ...;                         % fill based on response type (Hz)
+trans_pct = 100 * (delta_f / Fs);      % Transition width as % of sample rate
+
+% FIR length heuristic (sanity check only; not a guarantee)
+N_est = (Rs * Fs) / (22 * delta_f);
+
+% Max decimation factor is straightforward for LOWPASS cases:
+% M_max ≈ floor(Fs / (2 * Fstop))
+% For highpass/band* cases, safe decimation depends on spectral placement and is not a single formula.
+M_max = floor(Fs / (2 * Fstop));
+```
+
+
+        ### Prefer MATLAB-Native FIR Order Estimators (recommended)
+
+        The heuristic `N_est = (Rs * Fs)/(22 * Δf)` is **sanity-check only**. For a more standard, MATLAB-native estimate:
+
+        - **Kaiser window estimate**: `kaiserord` (good quick order estimate for windowed FIR)
+        - **Equiripple estimate**: `firpmord` (order estimate for Parks–McClellan FIR)
+
+        ```matlab
+        % Convert dB specs to linear deviations
+        dev_p = (10^(Rp/20)-1) / (10^(Rp/20)+1);
+        dev_s = 10^(-Rs/20);
+
+        % LOWPASS example (adapt f/a for other responses):
+        f = [Fpass Fstop];     % Hz
+        a = [1 0];             % desired amplitudes in each band
+        dev = [dev_p dev_s];   % linear deviations
+
+        [N_kaiser, Wn, beta, ftype] = kaiserord(f, a, dev, Fs);
+        [N_pm, fo, ao, w] = firpmord(f, a, dev, Fs);
+
+        fprintf("Order estimates: Kaiser=%d, Equiripple=%d
+", N_kaiser, N_pm);
+        ```
+
+        **Workflow recommendation**:
+        1) Use `kaiserord`/`firpmord` to estimate if a single-stage FIR is plausible.
+        2) Design the real filter (e.g., `designfilt(..., DesignMethod="equiripple")`).
+        3) Verify with `freqz` + measured `Rp_meas_dB` / `Rs_meas_dB`.
+
+
+### Decision Matrix
+
+| trans_pct | Action |
+|-----------|--------|
+| > 5% | Single-stage OK |
+| 2-5% | Mention multistage option |
+| < 2% | **Present tradeoff to user** (see `cards/efficient-filtering.md`) |
+
+### Response Template
+
+> "Architecture check: Transition BW = X% of Fs, estimated ~Y taps. [Single-stage recommended / Multistage recommended - asking user preference]."
+
+---
+
+## Streaming vs Offline
+
+### Offline Processing
+
+- Use `filtfilt()` for zero-phase
+- Use `resample()` for multirate
+- Process entire signal at once
+- No state management needed
+
+### Streaming/Real-Time
+
+- Use `dsp.SOSFilter` with `SystemObject=true`
+- Or use `ctffilt()` (R2024b+) with state management
+- Process frame-by-frame
+- Reset state when needed
+
+### Key Rule
+
+**Offline zero-phase** → `resample()` + `filtfilt()`
+**Streaming causal** → System objects + `filter()`
+
+Never mix: System objects with `filtfilt()` = catastrophic failure (see `gotchas.md` #10)
+
+---
+
+## Performance Optimization
+
+### Long FIR Filters
+
+```matlab
+if length(b) > 100
+    y = fftfilt(b, x);  % FFT-based, faster
+else
+    y = filter(b, 1, x);  % Direct form OK
+end
+```
+
+### Narrow Transition Bands
+
+- Consider multistage approach
+- Calculate efficiency gain: `(N_single) / (N_dec + N_sharp/M + N_interp)`
+- For trans_pct < 2%, multistage often 5-10x more efficient (see `cards/efficient-filtering.md`)
+
+### IIR Numerical Stability
+
+- Always use SOS form via `designfilt()` or `zp2sos()`
+- Avoid `[b,a]` form for order > 8
+- Check pole locations if stability concerns arise
+
+---
+
+## Quick Lookup
+
+| Topic | Consult |
+|-------|---------|
+| Common errors | `gotchas.md` |
+| Code templates | `patterns.md` |
+| API details | `docs/INDEX.md` |
+| Architecture decision | Pre-Design Check above |
+| Offline vs streaming | Streaming vs Offline section |
+| Validation | Validation Workflow section |
+

--- a/skills/matlab-digital-filter-design/knowledge/cards/designfilt.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/designfilt.md
@@ -1,0 +1,143 @@
+# designfilt Reference Card
+
+Open this card **before** writing any `designfilt(...)` call.
+
+## Response Type Quick Reference
+
+| Filter type | Response string | Key parameters |
+|-------------|-----------------|----------------|
+| Lowpass FIR | `"lowpassfir"` | `PassbandFrequency`, `StopbandFrequency` |
+| Lowpass IIR | `"lowpassiir"` | `PassbandFrequency`, `StopbandFrequency` |
+| Highpass FIR | `"highpassfir"` | `StopbandFrequency`, `PassbandFrequency` |
+| Highpass IIR | `"highpassiir"` | `StopbandFrequency`, `PassbandFrequency` |
+| Bandpass FIR | `"bandpassfir"` | `PassbandFrequency=[f1 f2]` (vector OK) |
+| Bandpass IIR | `"bandpassiir"` | `PassbandFrequency1`, `PassbandFrequency2` (scalar!) |
+| Bandstop FIR | `"bandstopfir"` | `StopbandFrequency=[f1 f2]` (vector OK) |
+| Bandstop IIR | `"bandstopiir"` | `StopbandFrequency1`, `StopbandFrequency2` (scalar!) |
+| **Notch (single tone)** | `"notchiir"` | `CenterFrequency`, `QualityFactor` |
+| Peak (boost) | `"peakiir"` | `CenterFrequency`, `QualityFactor`, `PassbandRipple` |
+
+## Core Patterns
+
+### FIR (linear phase by default)
+
+```matlab
+d = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+```
+
+### IIR (minimum order)
+
+```matlab
+d = designfilt("lowpassiir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="ellip");
+```
+
+### Notch (single tone removal)
+
+```matlab
+d = designfilt("notchiir", ...
+    CenterFrequency=f0, QualityFactor=Q, ...
+    SampleRate=Fs);
+```
+
+**Q guidelines**: 10-50 typical. Higher Q = sharper notch but more ringing.
+
+### Bandpass IIR (scalar edges required!)
+
+```matlab
+d = designfilt("bandpassiir", ...
+    StopbandFrequency1=fs1, PassbandFrequency1=f1, ...
+    PassbandFrequency2=f2,  StopbandFrequency2=fs2, ...
+    PassbandRipple=Rp, ...
+    StopbandAttenuation1=Rs, StopbandAttenuation2=Rs, ...
+    SampleRate=Fs, DesignMethod="ellip");
+```
+
+## Design Methods
+
+| Method | Characteristics |
+|--------|-----------------|
+| `"ellip"` | Minimum order, equiripple in pass & stop |
+| `"butter"` | Maximally flat, monotonic response |
+| `"cheby1"` | Ripple in passband only |
+| `"cheby2"` | Ripple in stopband only |
+| `"equiripple"` | Parks-McClellan (FIR only) |
+
+## SystemObject=true (streaming)
+
+For streaming applications, get a System object directly:
+
+```matlab
+% Returns dsp.SOSFilter (IIR) or dsp.FIRFilter (FIR)
+sosFilter = designfilt("lowpassiir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    SampleRate=Fs, DesignMethod="ellip", ...
+    SystemObject=true);
+
+y = sosFilter(x);  % Stateful, ready for streaming
+```
+
+---
+
+## Gotchas
+
+### IIR bandpass/bandstop vector error
+
+**Wrong**:
+```matlab
+d = designfilt("bandpassiir", ...
+    PassbandFrequency=[300 3400], ...);  % ERROR! Vector not allowed for IIR
+```
+
+**Correct**: Use scalar properties with `...1`/`...2` suffixes.
+
+**Note**: FIR bandpass/bandstop CAN use vectors: `PassbandFrequency=[f1 f2]`
+
+### Deprecated Coefficients property
+
+**Wrong**: `sos = d.Coefficients;` (removed in recent versions)
+
+**Correct**:
+```matlab
+B = d.Numerator;      % Lx3 per-section
+A = d.Denominator;    % Lx3 per-section
+sos = [B A];          % Lx6 if needed
+```
+
+### Manual dsp.SOSFilter vs SystemObject=true
+
+Don't manually extract coefficients to create a System object:
+```matlab
+% Inefficient
+d = designfilt(...); B = d.Numerator; A = d.Denominator;
+sosFilter = dsp.SOSFilter('Numerator', B, 'Denominator', A);
+
+% Efficient - get System object directly
+sosFilter = designfilt(..., SystemObject=true);
+```
+
+### Ultra-high-Q notch (excessive ringing)
+
+**Problematic**: `QualityFactor=1000` causes long ringing
+
+**Better**: Use moderate Q (10-50). For multiple tones, use several moderate notches instead of one ultra-sharp notch.
+
+---
+
+## iirnotch / iircomb (alternative to designfilt)
+
+For simple notch filters, `iirnotch` is a quick alternative:
+
+```matlab
+wo = f0/(Fs/2);      % Normalized frequency
+bw = bandwidth/(Fs/2);  % Normalized bandwidth
+[b, a] = iirnotch(wo, bw);
+y = filter(b, a, x);
+```
+
+**Note**: Returns `[b, a]` coefficients, not a digitalFilter object.

--- a/skills/matlab-digital-filter-design/knowledge/cards/efficient-filtering.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/efficient-filtering.md
@@ -1,0 +1,165 @@
+# Efficient Filtering Card (`trans_pct < 2%`)
+
+Use this card when the transition band is **narrow** or you need to compare **compute cost** across architectures.
+
+```matlab
+trans_pct = 100 * (Fstop - Fpass) / Fs;
+```
+
+If `trans_pct < 2%`, a single-stage FIR may be hundreds of taps. **Stop and compare architectures** instead of committing early.
+
+## Step 0 — compute the planning metrics
+
+```matlab
+trans_bw  = Fstop - Fpass;
+trans_pct = 100 * trans_bw / Fs;
+M_max     = floor(Fs/(2*Fstop));   % upper bound for lowpass-safe decimation
+```
+
+## Step 1 — do not guess: confirm the intent
+
+You must know:
+- Mode: **streaming** (causal) vs **offline** (batch)
+- Phase: **zero-phase**, **linear-phase**, or **don't-care**
+- Whether internal **rate change** is acceptable (multirate pipelines)
+
+If any is unknown: ask, then stop.
+
+## Step 2 — pick the viable candidate families (don't force all four)
+
+For `trans_pct < 2%`, present **2–4 viable candidates**, not a fixed set.
+
+### Quick lookup: Mode × Phase → Viable families
+
+| Mode | Phase | Single-stage IIR | Single-stage FIR | Multirate | IFIR |
+|------|-------|------------------|------------------|-----------|------|
+| **Streaming** | linear-phase | ❌ | ✅ | ✅ polyphase | ✅ |
+| **Streaming** | don't-care | ✅ | ✅ | ✅ polyphase | ✅ |
+| **Offline** | zero-phase | ✅ `filtfilt()` | ✅ `filtfilt()` | ✅ `resample()+filtfilt()` | ✅ `filtfilt()` |
+| **Offline** | linear-phase | ❌ | ✅ | ✅ polyphase | ✅ |
+| **Offline** | don't-care | ✅ | ✅ | ✅ either | ✅ |
+
+**Key insight**: Polyphase multirate (FIR decimator/interpolator) gives **linear-phase** — it's NOT limited to offline zero-phase workflows.
+
+### Family details
+
+| Family | Viable when | Quick notes |
+|---|---|---|
+| Single-stage **IIR** | phase ≠ "linear-phase" | Offline can use `filtfilt()` for zero-phase. Streaming IIR is efficient but non-linear phase. |
+| Single-stage **FIR** | always viable | Linear phase possible, but may be long / high latency / high MPIS. |
+| **Multirate pipeline** (dec→filter→interp) | rate change OK | **Streaming**: polyphase System objects (linear-phase). **Offline zero-phase**: `resample()` + `filtfilt()`. Never mix `filtfilt` with System objects. |
+| **Constant-rate multistage FIR** (IFIR method) | rate change NOT OK | FIR-like behavior at constant rate with fewer multipliers than single-stage FIR in many narrow-band cases. |
+
+If a family is excluded, say so explicitly (one line), e.g.:
+- "Excluded IIR: user requires linear phase in streaming."
+- "Excluded multirate: user cannot change internal sample rate."
+
+### Choosing between IFIR and Notch+LP
+
+When the spectrum shows a **dominant tonal interferer** near the transition band, consider a **Notch + relaxed LP** hybrid:
+
+| Approach | Best when |
+|----------|-----------|
+| **Notch + relaxed LP** | Known tonal interferer you can notch out (allows wider transition) |
+| **IFIR** | General narrow transition, no specific tone to exploit |
+| Single-stage FIR | Baseline (always works) |
+
+**Decision rule:**
+1. Analyze spectrum for dominant tones in/near transition band
+2. If tone found: try Notch (at tone freq) + relaxed LP (wider Fstop)
+3. Compare MPIS via `cost()` — pick the cheaper option
+4. If no identifiable tone → use IFIR or single FIR
+
+## Step 3 — feasibility check (order estimates)
+
+### Default "MATLAB-native" flow (recommended)
+
+Let `designfilt` pick the minimum order from `Rp/Rs`, then query `filtord(d)`.
+
+```matlab
+d_try = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+N = filtord(d_try);
+```
+
+### FIR planning estimates (useful for architecture decisions)
+
+```matlab
+dev_p = (10^(Rp/20)-1)/(10^(Rp/20)+1);  % passband deviation (linear)
+dev_s = 10^(-Rs/20);                    % stopband deviation (linear)
+
+[Nk,~,~,~] = kaiserord([Fpass Fstop],[1 0],[dev_p dev_s], Fs);
+[Np,~,~,~] = firpmord([Fpass Fstop],[1 0],[dev_p dev_s], Fs);
+```
+
+Use these as "order smell tests," not absolute truth.
+
+## Step 4 — compute MPIS with `cost()`
+
+**MPIS = Multiplications Per Input Sample**, reported by `cost()` on DSP System objects.
+
+### 80/20 rules
+
+- Tap count alone lies (multirate runs parts at lower rate; IIR cost isn't "sections × taps").
+- Prefer **System objects** + `cost()`:
+  - FIR → `dsp.FIRFilter`
+  - IIR → `dsp.SOSFilter` (often easiest via `designfilt(..., SystemObject=true)`)
+  - Pipelines → `dsp.FilterCascade`
+
+### FIR MPIS
+
+```matlab
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+firSys = dsp.FIRFilter("Numerator", d_fir.Numerator);
+mpis_fir = cost(firSys).MultiplicationsPerInputSample;
+```
+
+### IIR MPIS (prefer SystemObject=true)
+
+```matlab
+% Returns dsp.SOSFilter directly (stable + stateful)
+iirSys = designfilt("lowpassiir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="ellip", ...
+    SystemObject=true);
+
+mpis_iir = cost(iirSys).MultiplicationsPerInputSample;
+```
+
+### Pipeline MPIS
+
+```matlab
+pipe = dsp.FilterCascade(stage1, stage2, stage3);
+mpis_pipe = cost(pipe).MultiplicationsPerInputSample;
+```
+
+For multirate decimate→filter→interpolate pipelines, `cost(pipe)` accounts for polyphase structure and internal rates.
+
+### Offline `filtfilt()` note
+
+- `filtfilt()` runs the filter **twice** → compute cost is roughly **2×** the single-pass cost.
+- The effective magnitude response is **squared** (≈ doubles attenuation in dB).
+
+## Step 5 — compare with Filter Analyzer
+
+- Open `knowledge/cards/filter-analyzer.md` and overlay candidates.
+
+Minimum comparisons to show:
+- Magnitude response (meet specs)
+- Group delay (latency + phase behavior)
+- MPIS (when compute matters)
+
+---
+
+## `resample()` note
+
+`resample()` uses internal filters not exposed to `cost()`.
+If you need performance numbers for an offline `resample()` pipeline, use `timeit()` on your machine.

--- a/skills/matlab-digital-filter-design/knowledge/cards/filter-analyzer.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/filter-analyzer.md
@@ -1,0 +1,97 @@
+# Filter Analyzer Card
+
+Open this card **before** you write any code that uses:
+`filterAnalyzer`, `addFilters`, `addDisplays`, `replaceFilters`, `newSession`, or `filterAnalysisOptions`.
+
+## Non‑negotiables
+
+- Always pass `SampleRates=Fs` so plots are in **Hz** (not normalized).
+- `FilterNames` must be valid MATLAB identifiers:
+  - ✅ `["FIR_Equiripple","IIR_Ellip"]`
+  - ❌ `["FIR Equiripple","IIR-ellip"]`
+- Overlay rules:
+  - frequency-domain overlays only with frequency-domain
+  - time-domain overlays only with time-domain
+- Avoid duplicate filters on re-runs:
+  - prefer `newSession(fa)` (fresh start), or
+  - `replaceFilters(fa, ...)` (update-in-place)
+
+## Canonical “compare two filters” pattern
+
+```matlab
+Fs = 44100;
+
+% d1, d2 can be digitalFilter objects or supported System objects
+names = ["FIR_Equiripple","IIR_Ellip"];
+
+[fa, dispMag] = filterAnalyzer(d1, d2, ...
+    FilterNames=names, ...
+    SampleRates=Fs, ...
+    Analysis="magnitude", ...
+    OverlayAnalysis="phase");
+
+dispGD = addDisplays(fa, Analysis="groupdelay");
+showFilters(fa, true, FilterNames=names, DisplayNums=dispGD);
+
+dispImp = addDisplays(fa, Analysis="impulse");
+showFilters(fa, true, FilterNames=names, DisplayNums=dispImp);
+```
+
+## Robust session pattern (no duplicates across reruns)
+
+```matlab
+Fs = 44100;
+names = ["LP_A","LP_B"];
+
+if exist("fa","var") && isvalid(fa)
+    newSession(fa);
+else
+    fa = filterAnalyzer();  % open empty app
+end
+
+addFilters(fa, dA, dB, FilterNames=names, SampleRates=Fs);
+addDisplays(fa, Analysis="magnitude", OverlayAnalysis="phase");
+addDisplays(fa, Analysis="groupdelay");
+```
+
+## Update a filter without duplicating it
+
+```matlab
+% Replace existing filters by name (keeps displays intact)
+replaceFilters(fa, dA_new, dB_new, ...
+    FilterNames=["LP_A","LP_B"], ...
+    SampleRates=Fs);
+```
+
+## Visualize a multirate pipeline as one “filter”
+
+When comparing a decimate→filter→interpolate pipeline against a single-stage filter, wrap the full chain in `dsp.FilterCascade`.
+
+```matlab
+Fs = 44100; M = 4;
+
+% Streaming-friendly components (System objects)
+dec_sys = designMultirateFIR(DecimationFactor=M, StopbandAttenuation=60, SystemObject=true);
+
+d_core = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3100, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs/M, DesignMethod="equiripple");
+
+core_sys = dsp.FIRFilter("Numerator", d_core.Numerator);
+
+interp_sys = designMultirateFIR(InterpolationFactor=M, StopbandAttenuation=60, SystemObject=true);
+
+pipe = dsp.FilterCascade(dec_sys, core_sys, interp_sys);
+
+% Add alongside other filters
+addFilters(fa, pipe, FilterNames="Multirate_Pipeline", SampleRates=Fs);
+```
+
+## When to open the full guide
+
+Open `knowledge/filter-analyzer.md` when you need:
+- `filterAnalysisOptions` (log scale, NFFT, normalization, etc.)
+- display management (`duplicateDisplays`, `deleteDisplays`, …)
+- session save/load (`saveSession`)
+- version-specific notes

--- a/skills/matlab-digital-filter-design/knowledge/cards/general-iir-fir.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/general-iir-fir.md
@@ -1,0 +1,116 @@
+# General IIR/FIR Best Practices Card
+
+Open this card when working with high-order IIR, long FIR, `freqz`/`grpdelay` plots, or `filtfilt`.
+
+---
+
+## High-Order IIR: Use SOS Form
+
+The `[b, a]` transfer function form is **numerically unstable** for high-order IIR filters (order > 8).
+
+**Risky**:
+```matlab
+[b, a] = butter(12, 0.3);  % High-order [b,a] form
+y = filter(b, a, x);       % May produce Inf/NaN
+```
+
+**Better**:
+```matlab
+% Option 1: zpk → sos conversion
+[z, p, k] = butter(12, 0.3);
+sos = zp2sos(z, p, k);
+y = sosfilt(sos, x);
+
+% Option 2: designfilt (recommended - handles SOS internally)
+d = designfilt("lowpassiir", ...
+    FilterOrder=12, HalfPowerFrequency=0.3, ...
+    DesignMethod="butter");
+y = filter(d, x);  % Uses stable SOS form internally
+```
+
+---
+
+## Long FIR: Use fftfilt
+
+Direct convolution (`filter(b, 1, x)`) is slow for FIR filters > ~100 taps.
+
+```matlab
+b = d.Numerator;
+
+if length(b) > 100
+    y = fftfilt(b, x);  % FFT-based overlap-add (much faster)
+else
+    y = filter(b, 1, x);  % Direct form OK for short FIR
+end
+```
+
+**Rule of thumb**: For FIR length N and signal length L:
+- `filter()` is O(N*L)
+- `fftfilt()` is O(L*log(L)) — wins for large N
+
+---
+
+## freqz/grpdelay: Always Pass Fs
+
+Without `Fs`, plots show normalized frequency (0 to pi) — confusing!
+
+**Confusing**:
+```matlab
+freqz(d);  % Plots 0 to π normalized
+```
+
+**Clear**:
+```matlab
+freqz(d, [], Fs);     % Plots in Hz
+grpdelay(d, [], Fs);  % Group delay axis in Hz
+```
+
+Also applies to `phasez`, `zerophase`, etc.
+
+---
+
+## filtfilt: Offline Only!
+
+`filtfilt()` requires the **entire signal** (forward-backward filtering). It is **not** compatible with streaming/real-time.
+
+**Wrong** (real-time loop):
+```matlab
+for frame = 1:numFrames
+    y = filtfilt(d, x_frame);  % ERROR: filtfilt needs entire signal
+end
+```
+
+**Correct** (streaming):
+```matlab
+% Use a System object with state management
+sosFilt = dsp.SOSFilter('Numerator', B, 'Denominator', A);
+for frame = 1:numFrames
+    y_frame = sosFilt(x_frame);  % Causal, state preserved
+end
+```
+
+**Correct** (offline zero-phase):
+```matlab
+y_offline = filtfilt(d, entire_signal);
+```
+
+### filtfilt doubles attenuation
+
+`filtfilt` applies the filter twice (forward + backward), so:
+- Effective magnitude = |H(f)|^2
+- Stopband attenuation roughly doubles in dB
+- Passband ripple roughly doubles in dB
+
+Account for this when specifying `Rs` and `Rp`.
+
+---
+
+## Quick Checklist
+
+| Situation | Action |
+|-----------|--------|
+| IIR order > 8 | Use `designfilt` or `zp2sos` + `sosfilt` |
+| FIR length > 100 | Use `fftfilt()` |
+| Plotting frequency response | Pass `Fs` to `freqz`, `grpdelay` |
+| Real-time filtering | Use `dsp.SOSFilter` or `dsp.FIRFilter` |
+| Zero-phase offline | Use `filtfilt()` on entire signal |

--- a/skills/matlab-digital-filter-design/knowledge/cards/multirate-offline.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/multirate-offline.md
@@ -1,0 +1,63 @@
+# Multirate OFFLINE Card (rate change + zero‑phase)
+
+Use this card when the user wants:
+- output returned to the **original sample rate**, but
+- is OK with an **internal rate change**, and
+- wants **offline / batch** processing (zero‑phase is on the table).
+
+## Critical Gotcha: System Objects + filtfilt = Catastrophic
+
+**Never** combine multirate System objects with `filtfilt()`:
+
+```matlab
+% WRONG - causes severe signal degradation (e.g., -27 dB SNR)
+decimator = dsp.FIRDecimator(M, b_dec);
+interpolator = dsp.FIRInterpolator(M, b_interp);
+
+x_dec = decimator(x);              % System object has internal state
+x_filt = filtfilt(d, x_dec);       % filtfilt assumes no state - MISALIGNED!
+y = interpolator(x_filt);          % Output is garbage
+```
+
+**Why**: System objects maintain internal state and group delays. `filtfilt()` processes forward/backward assuming clean start states, causing catastrophic misalignment.
+
+**Solution**: Use `resample()` for offline zero-phase multirate:
+
+```matlab
+x_dec = resample(x, 1, M);         % Built-in anti-alias, proper alignment
+x_filt = filtfilt(d_sharp, x_dec); % Zero-phase at reduced rate
+y = resample(x_filt, M, 1);        % Interpolate back properly
+```
+
+## Canonical offline pipeline
+
+```matlab
+Fs = 44100;
+M  = 4;
+Fs_dec = Fs/M;
+
+% 1) Downsample with built-in anti-aliasing
+x_dec = resample(x, 1, M);
+
+% 2) Design the sharp filter at the reduced rate
+d_sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs_dec, DesignMethod="equiripple");
+
+% 3) Zero-phase filtering at low rate
+y_dec = filtfilt(d_sharp, x_dec);
+
+% 4) Upsample back (built-in anti-imaging)
+y = resample(y_dec, M, 1);
+```
+
+## Notes that avoid “confident nonsense”
+
+- `resample()` has hidden filter cost (not exposed via `cost()`).
+  - Use `timeit()` if you need wall-clock timing.
+- If you use `filtfilt(d_sharp, ...)`, the effective magnitude response is **squared**.
+  - Expect stopband attenuation in dB to roughly **double**.
+- For architecture choice (narrow transitions), compare against:
+  - single-stage FIR (high MPIS),
+  - constant-rate multistage FIR (IFIR), if rate change is not acceptable.

--- a/skills/matlab-digital-filter-design/knowledge/cards/multirate-streaming.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/multirate-streaming.md
@@ -1,0 +1,100 @@
+# Multirate STREAMING Card (polyphase, causal)
+
+Use this card when the user wants:
+- **streaming / real-time / frame-based** filtering, and
+- output stays at the **original sample rate**, but
+- internal rate change is acceptable.
+
+## 80/20 rules
+
+- Streaming is **causal** → no `filtfilt()`. (Zero-phase requires the entire signal.)
+- Use **System objects** (`SystemObject=true`) so state is handled correctly across frames.
+- Frame length should be a multiple of the decimation factor `M`.
+
+**Note**: If you need zero-phase, switch to offline mode with `resample()`. See `cards/multirate-offline.md`.
+
+## Canonical streaming pipeline (dec → sharp filter → interp)
+
+```matlab
+Fs = 44100;
+M  = 4;
+Fs_dec = Fs/M;
+
+% Stage 1: decimator (polyphase)
+dec = designMultirateFIR(DecimationFactor=M, ...
+    StopbandAttenuation=60, ...
+    SystemObject=true);
+
+% Stage 2: sharp filter at low rate (System object for streaming)
+sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs_dec, DesignMethod="equiripple", ...
+    SystemObject=true);
+
+% Stage 3: interpolator (polyphase)
+interp = designMultirateFIR(InterpolationFactor=M, ...
+    StopbandAttenuation=60, ...
+    SystemObject=true);
+
+% Frame loop (example)
+frameLen = 1024;              % choose so mod(frameLen,M)==0
+y = zeros(size(x));
+reset(dec); reset(sharp); reset(interp);
+
+for k = 1:frameLen:(numel(x)-frameLen+1)
+    frame = x(k:k+frameLen-1);
+
+    frame_dec  = dec(frame);
+    frame_filt = sharp(frame_dec);
+    frame_out  = interp(frame_filt);
+
+    y(k:k+frameLen-1) = frame_out;
+end
+```
+
+## Efficiency note (common trap)
+
+For narrow transitions, don’t try to “bake the sharp spec” into a multistage decimator/interpolator.  
+Instead:
+- decimate/interpolate with relaxed anti-alias / anti-image, and
+- do the sharp filtering at the reduced rate.
+
+See `knowledge/multirate.md` for the full decision guide.
+
+## Filter Analyzer comparison (pipeline as one object)
+
+Wrap the pipeline in `dsp.FilterCascade` (then open the Filter Analyzer card):
+
+```matlab
+pipe = dsp.FilterCascade(dec, sharp, interp);
+filterAnalyzer(pipe, FilterNames="Multirate_Pipeline", SampleRates=Fs);
+```
+
+## Gotchas
+
+### API confusion: designMultirateFIR vs dsp.FIRDecimator
+
+`designMultirateFIR` is the recommended modern API. Don't confuse it with raw System object constructors:
+
+```matlab
+% WRONG — invalid syntax (dsp.FIRDecimator doesn't take 'SystemObject')
+decim = dsp.FIRDecimator(M, 'SystemObject', true);
+
+% RIGHT — use designMultirateFIR
+decim = designMultirateFIR(DecimationFactor=M, StopbandAttenuation=60, SystemObject=true);
+```
+
+`dsp.FIRDecimator(M)` creates a default decimator; `designMultirateFIR` gives you spec control.
+
+### Querying filter order from System objects
+
+`filtord()` works on `digitalFilter` objects but NOT on System objects:
+
+```matlab
+% WRONG — filtord doesn't work on dsp.FIRDecimator
+N = filtord(decim);  % ERROR
+
+% RIGHT — use Numerator property
+N = numel(decim.Numerator) - 1;
+```

--- a/skills/matlab-digital-filter-design/knowledge/cards/multistage-ifir.md
+++ b/skills/matlab-digital-filter-design/knowledge/cards/multistage-ifir.md
@@ -1,0 +1,93 @@
+# Constant‑Rate Multistage FIR Card (IFIR method)
+
+Use this card when:
+- the transition is narrow (`trans_pct < 2%`), and
+- you want **FIR-like phase behavior** (often linear phase), and
+- you **cannot** (or don’t want to) change the sample rate internally.
+
+MATLAB’s standard tool for this is **IFIR** (Interpolated FIR): a sparse “model” filter plus an image‑suppressor, in cascade.
+
+## Two workflows (pick based on what you need)
+
+### A) Filter Analyzer / streaming-friendly (recommended)
+
+This returns a `dsp.FilterCascade` that Filter Analyzer understands.
+
+```matlab
+Fs = 44100;
+Fn = Fs/2;
+
+Hf = fdesign.lowpass(Fpass/Fn, Fstop/Fn, Rp, Rs);
+
+% Returns dsp.FilterCascade
+ifirSys = ifir(Hf, SystemObject=true);
+% (equivalent) ifirSys = design(Hf, "ifir", SystemObject=true);
+
+filterAnalyzer(ifirSys, FilterNames="IFIR", SampleRates=Fs);
+
+% Apply (streaming/casual)
+y = ifirSys(x);
+reset(ifirSys);
+```
+
+### B) Offline zero‑phase with coefficient access
+
+Raw coefficients are convenient for `filtfilt()`, but they don’t drop cleanly into Filter Analyzer.
+
+```matlab
+Fs = 44100;
+Fn = Fs/2;
+
+dev_p = (10^(Rp/20)-1)/(10^(Rp/20)+1);
+dev_s = 10^(-Rs/20);
+
+L = 4;  % interpolation factor (try 2–8)
+[b_ifir, b_model, b_image] = ifir(L, "low", [Fpass Fstop]/Fn, [dev_p dev_s]);
+
+y = filtfilt(b_ifir, 1, x);  % zero-phase (offline only)
+```
+
+## Gotchas
+
+### IFIR + Filter Analyzer / filtord
+
+**Problem**: Raw `ifir()` coefficient outputs don't work with `filterAnalyzer` or `filtord`:
+
+```matlab
+% These will ERROR or give wrong results
+[b_ifir, b_model, b_image] = ifir(L, "low", [Fpass Fstop]/Fn, [dev_p dev_s]);
+filterAnalyzer(b_ifir, SampleRates=Fs);  % ERROR
+filtord(b_ifir);  % Works but gives wrong answer (overall, not per-stage)
+
+% design() returns dfilt objects, not digitalFilter
+d_ifir = design(fdesign.lowpass(...), 'ifir');
+filtord(d_ifir.Stage(1));  % ERROR: dfilt.dffir not supported
+```
+
+**Solution**: Use `SystemObject=true` to get a `dsp.FilterCascade`:
+
+```matlab
+Hf = fdesign.lowpass(Fpass/Fn, Fstop/Fn, Rp, Rs);
+ifirSys = ifir(Hf, SystemObject=true);
+
+% Works with Filter Analyzer
+filterAnalyzer(ifirSys, FilterNames="IFIR", SampleRates=Fs);
+
+% Get tap counts via cost()
+c = cost(ifirSys);
+fprintf("Total multiplications per sample: %d\n", c.MultiplicationsPerInputSample);
+```
+
+### Getting stage coefficients for filtfilt
+
+If you need raw coefficients (e.g., for `filtfilt`), use workflow B and apply directly:
+
+```matlab
+[b_ifir, ~, ~] = ifir(L, "low", [Fpass Fstop]/Fn, [dev_p dev_s]);
+y = filtfilt(b_ifir, 1, x);  % OK - raw coefficients work here
+```
+
+## When to prefer multirate instead
+
+If internal rate change *is* acceptable, multirate dec→filter→interp can be even cheaper.  
+Use `knowledge/cards/multirate-streaming.md` or `multirate-offline.md` depending on Mode.

--- a/skills/matlab-digital-filter-design/knowledge/efficient-filtering.md
+++ b/skills/matlab-digital-filter-design/knowledge/efficient-filtering.md
@@ -1,0 +1,376 @@
+# Efficient Filtering for Narrow Transitions
+
+When transition bands are narrow (trans_pct < 2%; see `cards/efficient-filtering.md`), single-stage FIR filters require hundreds of taps. This guide helps you choose an efficient alternative.
+
+## Table of Contents
+- [When You Need This](#when-you-need-this)
+- [Four Approaches Compared](#four-approaches-compared)
+- [Quantify Single-Stage FIR Cost](#quantify-single-stage-fir-cost)
+- [Multirate Design](#multirate-design-function-selection)
+- [IFIR Quick Syntax](#ifir-quick-syntax)
+- [Decision Flowchart](#decision-flowchart)
+- [MPIS Cost Comparison](#mpis-cost-comparison-real-example)
+- [Why MPIS is the Right Metric](#why-mpis-is-the-right-metric)
+- [Visualizing All Approaches in Filter Analyzer](#visualizing-all-approaches-in-filter-analyzer)
+- [Quick Selection Guide](#quick-selection-guide)
+- [Cross-References](#cross-references)
+
+---
+
+## When You Need This
+
+Calculate your transition percentage:
+
+```
+Compute constraining transition width Δf (Hz):
+- lowpass:   Δf = Fstop - Fpass
+- highpass:  Δf = Fpass - Fstop
+- bandpass:  Δf = min(Fpass1 - Fstop1, Fstop2 - Fpass2)
+- bandstop:  Δf = min(Fstop1 - Fpass1, Fpass2 - Fstop2)
+
+Then:
+trans_pct = 100 * (Δf / Fs)
+```
+
+| trans_pct | Recommendation |
+|-----------|----------------|
+| > 5% | Single-stage filter is fine |
+| 2-5% | Consider efficient alternatives |
+| **< 2%** | **Efficient approach strongly recommended** (see `cards/efficient-filtering.md`) |
+
+---
+
+## Four Approaches Compared
+
+| Approach | Sample Rate | Structure | Best When |
+|----------|-------------|-----------|-----------|
+| **Single-stage IIR** | Constant | SOS (biquads) | Offline zero-phase OK, minimum coefficients |
+| **Multirate** | Changes internally | Decimate→filter→interpolate | Large M possible, prefer linear phase |
+| **IFIR** | Constant | Sparse + image suppressor | Rate change problematic, constant rate required |
+| **Single-stage FIR** | Constant | One filter | trans_pct > 5%, or simplicity matters |
+
+**Key insight**: For offline processing, **IIR + `filtfilt()`** is often the most efficient because `filtfilt()` cancels phase distortion, allowing minimum-order IIR designs.
+
+**Note**: Because `filtfilt()` applies the filter forward and backward, the effective magnitude response is the squared magnitude of the original filter (amplitude specs should be checked on the combined response).
+---
+
+## Quantify Single-Stage FIR Cost
+
+Before you jump to multirate/IFIR, **quantify how bad a single-stage FIR really is** using MATLAB-native estimators.
+
+```matlab
+% Convert dB specs to linear deviations
+dev_p = (10^(Rp_dB/20)-1) / (10^(Rp_dB/20)+1);
+dev_s = 10^(-Rs_dB/20);
+
+% LOWPASS example (Hz). Adapt f/a for other responses:
+f = [Fpass Fstop];
+a = [1 0];
+dev = [dev_p dev_s];
+
+% Order estimates
+[N_kaiser, Wn, beta, ftype] = kaiserord(f, a, dev, Fs);
+[N_pm, fo, ao, w] = firpmord(f, a, dev, Fs);
+
+fprintf("Estimated FIR order: Kaiser=%d, Equiripple=%d
+", N_kaiser, N_pm);
+```
+
+**Interpretation**:
+- If the estimate is already in the **hundreds of taps**, a single-stage linear-phase FIR is likely expensive in streaming.
+- If the estimate is modest, you may not need multirate/IFIR at all — keep it simple and verify.
+
+
+---
+
+## Multirate Design: Function Selection
+
+For multirate approaches, select functions based on your goal:
+
+| Goal | Recommended Approach |
+|------|---------------------|
+| **Pure rate conversion** (wideband anti-alias) | `designMultistageDecimator/Interpolator` with default TW |
+| **Narrow-transition filtering** at reduced rate | `designMultirateFIR` (anti-alias) + separate sharp filter |
+| **Offline FIR-based rate conversion** (delay-compensated) | `resample()` |
+
+### When Multistage Excels
+
+`designMultistageDecimator/Interpolator` automatically factor the overall rate-change (when the factor is composite) into stages and select a stage sequence that minimizes MPIS.
+
+**Example** (from MathWorks docs): For M=48 decimation, multistage reduces MPIS from ~15.7 to ~7.3 — roughly 2× savings.
+
+**Note**: Actual savings depend heavily on TW, Astop, and factorization. Use `cost()` to compare specific designs.
+
+These functions are optimized for **wideband anti-aliasing**. Default transition width depends on the function and MATLAB release:
+- `designMultistageDecimator`: default TW = 0.2×Fs/M
+- `designMultistageInterpolator`: default TW = 0.2×Fs (R2024b+; was 0.2×Fs/L previously)
+
+### Narrow-Transition Strategy
+
+For narrow transition bands, the sharp filtering is more efficient at reduced sample rate:
+
+1. **Decimate** with relaxed anti-alias (`designMultirateFIR`)
+2. **Sharp filter** at reduced rate (`designfilt` with tight specs)
+3. **Interpolate** with anti-image (`designMultirateFIR`)
+
+This separates the anti-aliasing (wideband) from the sharp filtering (narrowband), allowing each to be optimized independently.
+
+
+
+        ### Multirate Candidate Selection Recipe (repeatable)
+
+        For lowpass-style “keep baseband” problems, start with:
+
+        ```matlab
+        % Max decimation factor that keeps stopband below new Nyquist (lowpass heuristic)
+        M_max = floor(Fs / (2*Fstop));
+        M_try = [2 3 4 5 6 8];
+        M_try = M_try(M_try <= M_max);
+        ```
+
+        Then evaluate each `M` by **total MPIS** (multiplications per input sample):
+
+        ```matlab
+        best = struct(M=1, mpis=Inf);
+
+        for M = M_try
+            Fs_dec = Fs / M;
+
+            % Anti-alias / anti-image (relaxed) at full rate
+            dec = designMultirateFIR(DecimationFactor=M, StopbandAttenuation=Rs_dB, SystemObject=true);
+            interp = designMultirateFIR(InterpolationFactor=M, StopbandAttenuation=Rs_dB, SystemObject=true);
+
+            % Sharp filter at reduced rate (digitalFilter -> wrap for cost())
+            d_sharp = designfilt("lowpassfir", ...
+                PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+                PassbandRipple=Rp_dB, StopbandAttenuation=Rs_dB, ...
+                SampleRate=Fs_dec, DesignMethod="equiripple");
+            sharp = dsp.FIRFilter(Numerator=d_sharp.Numerator);
+
+            mpis_total = cost(dec).MultiplicationsPerInputSample + ...
+                         cost(sharp).MultiplicationsPerInputSample / M + ...
+                         cost(interp).MultiplicationsPerInputSample;
+
+            if mpis_total < best.mpis
+                best.M = M; best.mpis = mpis_total;
+            end
+        end
+
+        fprintf("Best multirate candidate: M=%d (%.2f MPIS)
+", best.M, best.mpis);
+        ```
+
+        **Why this is “standard”**: it turns “multirate might help” into a repeatable cost-based selection, instead of a vibe-based guess.
+
+        **Caveat**: `M_max` above is a *lowpass heuristic*. For highpass/bandpass/bandstop, safe rate-change needs spectrum-aware reasoning.
+
+→ See `knowledge/multirate.md` for complete workflows and cost analysis examples.
+
+---
+
+## IFIR Quick Syntax
+
+**Method 1: Direct ifir() with linear deviations**
+```matlab
+% WARNING: ifir() uses LINEAR deviations, not dB!
+delta_p = 10^(Rp_dB/20) - 1;  % passband deviation
+delta_s = 10^(-Rs_dB/20);      % stopband deviation
+[h, g] = ifir(L, 'low', [f1 f2], [delta_p delta_s]);
+y = filter(g, 1, filter(h, 1, x));  % cascade application
+
+% For Filter Analyzer: wrap in System objects
+H = dsp.FIRFilter(Numerator=h);
+G = dsp.FIRFilter(Numerator=g);
+filterAnalyzer(cascade(H,G), FilterNames="IFIR_Cascade");
+```
+
+**Method 2: fdesign + ifir (Recommended for Filter Analyzer)**
+```matlab
+% Returns dsp.FilterCascade directly - works with filterAnalyzer
+Hf = fdesign.lowpass(Fpass/(Fs/2), Fstop/(Fs/2));
+Hd = ifir(Hf, SystemObject=true);
+filterAnalyzer(Hd, FilterNames="IFIR_Lowpass");
+```
+
+---
+
+## Decision Flowchart
+
+```
+Narrow transition band (trans_pct < 2%)?
+│
+├── No  → Single-stage filter is fine
+│         - FIR for linear phase (streaming)
+│         - IIR for efficiency
+│
+└── Yes → Is this offline or streaming?
+    │
+    ├── OFFLINE → Do you need linear phase (constant group delay)?
+    │   │
+    │   ├── No  → **IIR + filtfilt()** (BEST: 23 MPIS)
+    │   │         Zero-phase, far fewer coefficients
+    │   │
+    │   └── Yes → Choose efficient FIR approach:
+    │             ├── Can you tolerate internal rate change?
+    │             │   ├── Yes → **Multirate** (decimate→filter→interpolate)
+    │             │   └── No  → **IFIR** (constant rate)
+    │             └── Or just accept ~400 taps if simplicity matters
+    │
+    └── STREAMING → Do you need linear phase?
+        │
+        ├── No  → **IIR** (minimum order, sharp cutoff)
+        │
+        └── Yes → Choose efficient FIR approach:
+                  ├── Can you tolerate internal rate change?
+                  │   ├── Yes → **Multirate** (System objects)
+                  │   └── No  → **IFIR** (constant rate)
+                  └── Or accept latency of ~400-tap FIR
+```
+
+---
+
+## MPIS Cost Comparison (Real Example)
+
+**Specifications**: Fs=44.1kHz, Fpass=2.8kHz, Fstop=3.1kHz, 60dB stopband (trans_pct = 0.68%)
+
+```matlab
+%% Measure MPIS with cost() function
+Fs = 44100; Fpass = 2800; Fstop = 3100; Rs = 60;
+
+% FIR Equiripple
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    StopbandAttenuation=Rs, SampleRate=Fs, DesignMethod="equiripple");
+fir_sys = dsp.FIRFilter('Numerator', d_fir.Numerator);
+cost_fir = cost(fir_sys);
+
+% IIR Elliptic
+d_iir = designfilt("lowpassiir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    StopbandAttenuation=Rs, SampleRate=Fs, DesignMethod="ellip");
+iir_sys = dsp.SOSFilter('Numerator', d_iir.Numerator, 'Denominator', d_iir.Denominator);
+cost_iir = cost(iir_sys);
+
+fprintf('FIR Equiripple: %d taps, %.0f MPIS\n', length(d_fir.Numerator), cost_fir.MultiplicationsPerInputSample);
+fprintf('IIR Elliptic:   %d sections, %.0f MPIS\n', size(d_iir.Numerator,1), cost_iir.MultiplicationsPerInputSample);
+```
+
+**Results**:
+
+| Filter | Taps/Sections | MPIS | Relative Cost |
+|--------|---------------|------|---------------|
+| FIR Equiripple | 407 taps | **407** | 1.00× (baseline) |
+| IIR Elliptic | 5 sections | **23** | 0.06× (**17× more efficient**) |
+| FIR Decimator (M=4) | 96 taps | 18.25 | (per input sample) |
+| FIR Interpolator (L=4) | 96 taps | 72 | (per output sample) |
+
+---
+
+## Why MPIS is the Right Metric
+
+| Metric | Problem |
+|--------|---------|
+| **Tap count** | Ignores polyphase efficiency, IIR structure, rate changes |
+| **`timeit()`** | Hardware-dependent, JIT-variable, not reproducible |
+| **MPIS via `cost()`** | Deterministic, structure-aware, MathWorks standard |
+
+Use the `cost()` function on DSP System objects to get accurate MPIS values.
+
+---
+
+## Visualizing All Approaches in Filter Analyzer
+
+**All filter types can be visualized together** in Filter Analyzer, including:
+- Single-stage FIR/IIR (`digitalFilter`, `dsp.FIRFilter`, `dsp.SOSFilter`)
+- IFIR cascades (`dsp.FilterCascade` from `ifir()`)
+- Multirate pipelines (`dsp.FilterCascade` wrapping dec→filter→interp)
+- Individual multirate filters (`dsp.FIRDecimator`, `dsp.FIRInterpolator`)
+
+### Complete Comparison Example (FIR vs IFIR vs Multirate Pipeline)
+
+**IMPORTANT**: For multirate pipelines, wrap the complete dec→filter→interp chain in `dsp.FilterCascade` so it appears as a single filter for comparison.
+
+```matlab
+%% Complete comparison: FIR vs IFIR vs Multirate Pipeline
+Fs = 44100; M = 4;
+Fpass = 2800; Fstop = 3000; Rp = 0.1; Rs = 60;
+
+% Approach 1: Single-stage FIR (baseline)
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+fir_sys = dsp.FIRFilter('Numerator', d_fir.Numerator);
+
+% Approach 2: IFIR cascade
+Hf = fdesign.lowpass(Fpass/(Fs/2), Fstop/(Fs/2), Rp, Rs);
+ifir_sys = ifir(Hf, 'SystemObject', true);
+
+% Approach 3: Multirate pipeline (dec → filter → interp)
+dec_sys = designMultirateFIR(DecimationFactor=M, StopbandAttenuation=Rs, SystemObject=true);
+d_core = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs/M, DesignMethod="equiripple");
+core_sys = dsp.FIRFilter('Numerator', d_core.Numerator);  % Wrap for cascade!
+interp_sys = designMultirateFIR(InterpolationFactor=M, StopbandAttenuation=Rs, SystemObject=true);
+multirate_cascade = dsp.FilterCascade(dec_sys, core_sys, interp_sys);
+
+% Open Filter Analyzer with ALL THREE
+fa = filterAnalyzer(fir_sys, ifir_sys, multirate_cascade, ...
+    FilterNames=["FIR_SingleStage", "IFIR_Cascade", "Multirate_Pipeline"], ...
+    SampleRates=Fs, Analysis="magnitude");
+
+% Add group delay and impulse response
+addDisplays(fa, Analysis="groupdelay");
+addDisplays(fa, Analysis="impulse");
+showFilters(fa, true);
+
+% Compare MPIS
+fprintf('MPIS: FIR=%.0f, IFIR=%.0f, Multirate=%.0f\n', ...
+    cost(fir_sys).MultiplicationsPerInputSample, ...
+    cost(ifir_sys).MultiplicationsPerInputSample, ...
+    cost(multirate_cascade).MultiplicationsPerInputSample);
+```
+
+**Key points:**
+- Wrap `digitalFilter` in `dsp.FIRFilter` before adding to `dsp.FilterCascade`
+- **Use `dsp.FilterCascade(dec, filter, interp)`** to create a single object for comparison
+- Filter Analyzer shows the **overall** frequency response of the cascade
+- Use same `SampleRates=Fs` for all (multirate rates are handled internally)
+- IFIR cascades automatically expand to show individual stages
+
+→ See `knowledge/filter-analyzer.md` § "Visualizing Multirate Pipelines" for more details.
+
+---
+
+## Quick Selection Guide
+
+| Your Situation | Recommended Approach | Details |
+|----------------|---------------------|---------|
+| Offline, zero-phase OK | **IIR + `filtfilt()`** | Simplest, most efficient |
+| Offline, linear phase needed, rate change OK | **Multirate** | `resample()` + sharp filter |
+| Offline, linear phase needed, constant rate | **IFIR** | `ifir()` function |
+| Streaming, no phase requirement | **IIR** | `dsp.SOSFilter` |
+| Streaming, linear phase, rate change OK | **Multirate** | System objects pipeline |
+| Streaming, linear phase, constant rate | **IFIR** | `ifir(..., SystemObject=true)` |
+
+---
+
+## Cross-References
+
+**Detailed Guides**:
+- **Multirate workflows** → `knowledge/multirate.md`
+- **IFIR/Multistage workflows** → `knowledge/multistage-ifir.md`
+
+**API Documentation**:
+- `docs/ref_designMultirateFIR.md` — Multirate FIR design
+- `docs/ref_designMultistageDecimator.md` — Optimal cascaded decimator
+- `docs/ref_designMultistageInterpolator.md` — Optimal cascaded interpolator
+- `docs/ref_ifir.md` — IFIR filter design
+- `docs/ref_resample.md` — Sample rate conversion
+- `docs/dsp_multirate-filtering.md` — Multirate concepts
+
+**Other Knowledge**:
+- `knowledge/filter-analyzer.md` — Visualizing and comparing filters
+- `knowledge/patterns.md` — Code templates for all approaches

--- a/skills/matlab-digital-filter-design/knowledge/filter-analyzer.md
+++ b/skills/matlab-digital-filter-design/knowledge/filter-analyzer.md
@@ -1,0 +1,513 @@
+# Filter Analyzer App Workflows
+
+Comprehensive guide for using the MATLAB Filter Analyzer app programmatically via `filterAnalyzer`.
+
+**Prefer Filter Analyzer over manual plotting** for filter visualization whenever comparing filters, iterating on designs, or needing interactive exploration.
+---
+
+## Table of Contents
+- [Analysis Types Quick Reference](#analysis-types-quick-reference)
+- [When to Use Filter Analyzer vs Manual Plots](#when-to-use-filter-analyzer-vs-manual-plots)
+- [Object Methods Quick Reference](#object-methods-quick-reference)
+- [Session Management](#session-management)
+- [Working with Analysis Options](#working-with-analysis-options)
+- [Workflow Examples](#workflow-examples)
+- [Getting Existing Filter Names](#getting-existing-filter-names-undocumented)
+- [Visualizing Multirate Filters](#visualizing-multirate-filters)
+- [Tips and Gotchas](#tips-and-gotchas)
+- [Version Info](#version-info)
+
+## Analysis Types Quick Reference
+
+| Analysis | Domain | Overlay? | Key Options |
+|----------|--------|----------|-------------|
+| `"magnitude"` | Freq | Yes | `MagnitudeMode`, `NormalizeMagnitude` |
+| `"phase"` | Freq | Yes | `PhaseUnits`, `ContinuousPhase` |
+| `"groupdelay"` | Freq | Yes | `GroupDelayUnits` |
+| `"phasedelay"` | Freq | Yes | `PhaseUnits` |
+| `"magestimate"` | Freq | Yes | `MagnitudeEstimateNumTrials` |
+| `"noisepsd"` | Freq | Yes | `NoisePSDNumTrials` |
+| `"impulse"` | Time | Yes | `ResponseLengthMode`, `ResponseLength` |
+| `"step"` | Time | Yes | `ResponseLengthMode`, `ResponseLength` |
+| `"polezero"` | Other | No | — |
+| `"info"` | Other | No | — |
+| `"coefficients"` | Other | No | `CoefficientsFormat` |
+
+**Overlay rules**: Frequency-domain analyses can overlay with other frequency-domain. Time-domain with time-domain. `polezero`, `info`, `coefficients` do not support overlays.
+
+---
+
+## When to Use Filter Analyzer vs Manual Plots
+
+### Use Filter Analyzer when:
+- Comparing multiple filters side-by-side
+- Need interactive exploration (zoom, pan)
+- Want overlay analysis (magnitude + phase, impulse + step)
+- Need specification mask visualization
+- Working iteratively (app stays open, update filters in place)
+- Need multiple analysis displays simultaneously
+
+### Use manual `freqz`/`grpdelay` when:
+- Simple single-filter quick check
+- Need to customize plot appearance beyond app options
+- Generating figures for export/publication (more control over formatting)
+- Scripting batch analysis without GUI
+
+---
+
+## Object Methods Quick Reference
+
+| Method | Syntax | Purpose |
+|--------|--------|---------|
+| `addFilters` | `addFilters(fa, filt1, filt2, ..., FilterNames=, SampleRates=)` | Add filters |
+| `addDisplays` | `dispNum = addDisplays(fa, Analysis=, OverlayAnalysis=)` | Add analysis display |
+| `deleteFilters` | `deleteFilters(fa, FilterNames=names)` | Remove filters by name |
+| `deleteDisplays` | `deleteDisplays(fa, DisplayNums=num)` | Remove display by number |
+| `duplicateDisplays` | `dupNum = duplicateDisplays(fa, DisplayNums=num)` | Clone a display |
+| `showFilters` | `showFilters(fa, true/false, FilterNames=, DisplayNums=)` | Show/hide filters |
+| `showLegend` | `showLegend(fa, true/false, DisplayNums=)` | Toggle legend |
+| `renameFilters` | `renameFilters(fa, oldNames, newNames)` | Rename filters |
+| `replaceFilters` | `replaceFilters(fa, filt1, ..., FilterNames=, SampleRates=)` | Update existing filters |
+| `getAnalysisOptions` | `opts = getAnalysisOptions(fa, DisplayNums=)` | Get display options |
+| `setAnalysisOptions` | `setAnalysisOptions(fa, opts, DisplayNums=)` | Set display options |
+| `zoom` | `zoom(fa, "passband"/"default", DisplayNums=)` | Zoom presets |
+| `saveSession` | `saveSession(fa, 'file.mat')` | Save session to file |
+| `newSession` | `newSession(fa)` | Clear all filters/displays |
+| `close` | `close(fa)` | Close the app |
+
+---
+
+## Session Management
+
+### Problem: Duplicate Filters Accumulating
+
+When repeatedly running code that adds filters to Filter Analyzer, you get:
+```
+FIR_Equiripple
+FIR_Equiripple_1
+FIR_Equiripple_2
+...
+```
+
+This happens because `filterAnalyzer()` or `addFilters()` appends to existing session.
+
+### Solution 1: Fresh Session (Recommended)
+
+Use `newSession(fa)` to clear all filters before adding new ones:
+
+```matlab
+% Get or create Filter Analyzer handle
+if exist('fa', 'var') && isvalid(fa)
+    newSession(fa);  % Clear all existing filters
+else
+    fa = filterAnalyzer();
+end
+
+% Now add filters - no duplicates
+addFilters(fa, d1, d2, d3, ...
+    FilterNames=["FIR_Equiripple", "FIR_Kaiser", "FIR_Hamming"], ...
+    SampleRates=Fs);
+```
+
+### Solution 2: Replace Existing Filters
+
+Use `replaceFilters()` to update filters by name (keeps app state, displays):
+
+```matlab
+fa = getFilterAnalyzerHandle;
+
+% Replace filters with same names
+replaceFilters(fa, d1_new, d2_new, d3_new, ...
+    FilterNames=["FIR_Equiripple", "FIR_Kaiser", "FIR_Hamming"], ...
+    SampleRates=Fs);
+```
+
+**Note**: `FilterNames` specifies WHICH existing filters to replace.
+
+### Solution 3: Delete Specific Filters
+
+Remove specific filters by name:
+
+```matlab
+fa = getFilterAnalyzerHandle;
+deleteFilters(fa, FilterNames=["FIR_Equiripple_1", "FIR_Kaiser_2"]);
+```
+
+---
+
+## Working with Analysis Options
+
+### Creating and Applying Options
+
+```matlab
+% Create options for specific analysis (with overlay)
+opts = filterAnalysisOptions("magnitude", "phase");
+opts.NFFT = 4096;
+opts.FrequencyScale = "log";
+opts.MagnitudeMode = "db";
+
+% Apply to specific display
+setAnalysisOptions(fa, opts, DisplayNums=2);
+
+% Get current options from a display
+currentOpts = getAnalysisOptions(fa, DisplayNums=2);
+```
+
+### Common filterAnalysisOptions Properties
+
+**All Frequency-Domain Analyses:**
+| Property | Values | Default |
+|----------|--------|---------|
+| `FrequencyNormalizationMode` | `"auto"`, `"normalized"`, `"unnormalized"` | `"auto"` |
+| `FrequencyRange` | `"auto"`, `"onesided"`, `"twosided"`, `"centered"` | `"auto"` |
+| `FrequencyScale` | `"linear"`, `"log"` | `"linear"` |
+| `NFFT` | positive integer | `8192` |
+| `ReferenceSampleRateMode` | `"max"`, `"specify"` | `"max"` |
+
+**Magnitude-Specific:**
+| Property | Values | Default |
+|----------|--------|---------|
+| `MagnitudeMode` | `"db"`, `"linear"`, `"squared"`, `"zerophase"` | `"db"` |
+| `NormalizeMagnitude` | `true`, `false` | `false` |
+
+**Phase-Specific:**
+| Property | Values | Default |
+|----------|--------|---------|
+| `PhaseUnits` | `"radians"`, `"degrees"` | `"radians"` |
+| `ContinuousPhase` | `true`, `false` | `false` |
+
+**Group Delay:**
+| Property | Values | Default |
+|----------|--------|---------|
+| `GroupDelayUnits` | `"samples"`, `"time"` | `"samples"` |
+
+**Time-Domain (impulse/step):**
+| Property | Values | Default |
+|----------|--------|---------|
+| `ResponseLengthMode` | `"auto"`, `"specify"` | `"auto"` |
+| `ResponseLength` | positive integer | (auto-computed) |
+
+**Coefficients Display:**
+| Property | Values | Default |
+|----------|--------|---------|
+| `CoefficientsFormat` | `"decimal"`, `"hex"`, `"binary"` | `"decimal"` |
+
+**CTF View (cascaded transfer functions):**
+| Property | Values | Default |
+|----------|--------|---------|
+| `CTFAnalysisMode` | `"complete"`, `"individual"`, `"cumulative"`, `"specify"` | `"complete"` |
+
+---
+
+## Workflow Examples
+
+### Example 1: Multi-Display Filter Comparison
+
+```matlab
+%% Compare Butterworth, Elliptic, and FIR filters
+Fs = 44100;
+
+% Design filters
+d_butter = designfilt("lowpassiir", ...
+    PassbandFrequency=2000, StopbandFrequency=2500, ...
+    PassbandRipple=1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="butter");
+
+d_ellip = designfilt("lowpassiir", ...
+    PassbandFrequency=2000, StopbandFrequency=2500, ...
+    PassbandRipple=1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="ellip");
+
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=2000, StopbandFrequency=2500, ...
+    PassbandRipple=1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+filterNames = ["Butterworth", "Elliptic", "FIR_Equiripple"];
+
+% Open with magnitude + phase overlay
+[fa, disp1] = filterAnalyzer(d_butter, d_ellip, d_fir, ...
+    FilterNames=filterNames, ...
+    SampleRates=Fs, ...
+    Analysis="magnitude", OverlayAnalysis="phase");
+
+% Add group delay display
+disp2 = addDisplays(fa, Analysis="groupdelay");
+showFilters(fa, true, FilterNames=filterNames, DisplayNums=disp2);
+
+% Add impulse + step response display
+disp3 = addDisplays(fa, Analysis="impulse", OverlayAnalysis="step");
+showFilters(fa, true, FilterNames=filterNames, DisplayNums=disp3);
+
+% Add pole-zero plot
+disp4 = addDisplays(fa, Analysis="polezero");
+showFilters(fa, true, FilterNames=filterNames, DisplayNums=disp4);
+
+% Customize magnitude display for log frequency scale
+opts = getAnalysisOptions(fa, DisplayNums=disp1);
+opts.FrequencyScale = "log";
+setAnalysisOptions(fa, opts, DisplayNums=disp1);
+```
+
+### Example 2: Iterative Design with Live Updates
+
+```matlab
+%% Iterative filter design - update without duplicates
+Fs = 48000;
+
+% Initial design
+d = designfilt("lowpassfir", ...
+    PassbandFrequency=1000, StopbandFrequency=1200, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+fa = filterAnalyzer(d, FilterNames="LP_Design", SampleRates=Fs, ...
+    Analysis="magnitude", OverlayAnalysis="phase");
+
+% ... user reviews, wants tighter transition band ...
+
+% Update design - replaceFilters keeps same name, no duplicates
+d_v2 = designfilt("lowpassfir", ...
+    PassbandFrequency=1000, StopbandFrequency=1100, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+replaceFilters(fa, d_v2, FilterNames="LP_Design", SampleRates=Fs);
+% Display updates in-place, no "LP_Design_1" created
+```
+
+### Example 3: Complete Session Management Pattern
+
+```matlab
+%% Robust pattern for repeated runs
+Fs = 44100;
+filterNames = ["FIR_Equiripple", "FIR_Kaiser", "FIR_Hamming"];
+
+% Design filters
+d_eq = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3100, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+d_kaiser = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3100, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="kaiserwin");
+
+d_hamming = designfilt("lowpassfir", ...
+    FilterOrder=200, CutoffFrequency=2950, ...
+    SampleRate=Fs, DesignMethod="window", Window=hamming(201));
+
+%% Visualize in Filter Analyzer (no duplicates on re-run)
+if exist('fa', 'var') && isvalid(fa)
+    % App already open - fresh start
+    newSession(fa);
+    addFilters(fa, d_eq, d_kaiser, d_hamming, ...
+        FilterNames=filterNames, SampleRates=Fs);
+else
+    % First run - create new session
+    fa = filterAnalyzer(d_eq, d_kaiser, d_hamming, ...
+        FilterNames=filterNames, SampleRates=Fs, ...
+        Analysis="magnitude", OverlayAnalysis="phase");
+end
+
+% Add more displays
+addDisplays(fa, Analysis="groupdelay");
+showFilters(fa, true, FilterNames=filterNames);
+
+addDisplays(fa, Analysis="impulse", OverlayAnalysis="step");
+showFilters(fa, true, FilterNames=filterNames);
+```
+
+---
+
+## Getting Existing Filter Names (Undocumented)
+
+No official API exists, but this helper function works:
+
+```matlab
+function names = getFilterAnalyzerFilterNames(fa)
+    % Get filter names from an open Filter Analyzer session
+    % Usage: names = getFilterAnalyzerFilterNames(fa)
+    %        names = getFilterAnalyzerFilterNames()  % auto-gets handle
+
+    if nargin < 1
+        fa = getFilterAnalyzerHandle;
+    end
+
+    warning('off', 'MATLAB:structOnObject');
+    try
+        s = struct(fa);
+        impl = s.FilterAnalyzerImpl;
+        implStruct = struct(impl);
+        faModel = struct(struct(implStruct.MainModel).FilterAnalyzerModel);
+        filterInfoMap = faModel.FilterInfoMap;
+
+        k = keys(filterInfoMap);
+        names = strings(1, length(k));
+
+        for i = 1:length(k)
+            fwa = struct(struct(filterInfoMap(k(i))).FilterWithAnalysis);
+            names(i) = string(fwa.Name);
+        end
+    catch ME
+        names = strings(0);
+        warning('Could not get filter names: %s', ME.message);
+    end
+    warning('on', 'MATLAB:structOnObject');
+end
+```
+
+**Example usage**:
+```matlab
+fa = getFilterAnalyzerHandle;
+existingNames = getFilterAnalyzerFilterNames(fa);
+disp(existingNames);  % ["FIR_Equiripple", "FIR_Kaiser", "FIR_Hamming"]
+```
+
+---
+
+## Visualizing Multirate Filters
+
+Filter Analyzer fully supports multirate System objects including `dsp.FIRDecimator`, `dsp.FIRInterpolator`, and `dsp.FilterCascade` (from multistage designs).
+
+### Example 1: Compare Decimator Designs
+
+```matlab
+%% Compare single-stage vs multistage decimators
+Fs = 44100;
+
+% Single-stage decimators
+dec4 = designMultirateFIR(DecimationFactor=4, SystemObject=true);
+dec8 = designMultirateFIR(DecimationFactor=8, SystemObject=true);
+
+% Multistage decimator (automatic cascade optimization)
+decMultistage = designMultistageDecimator(8);
+
+% Compare all three in Filter Analyzer
+filterAnalyzer(dec4, dec8, decMultistage, ...
+    SampleRates=Fs, ...
+    FilterNames=["Decim4_Single", "Decim8_Single", "Decim8_Multistage"], ...
+    Analysis="magnitude");
+```
+
+### Example 2: Compare Interpolator Designs
+
+```matlab
+%% Compare interpolators with different attenuation specs
+Fs = 48000;
+
+interp_60dB = designMultirateFIR(InterpolationFactor=4, ...
+    StopbandAttenuation=60, SystemObject=true);
+interp_80dB = designMultirateFIR(InterpolationFactor=4, ...
+    StopbandAttenuation=80, SystemObject=true);
+
+filterAnalyzer(interp_60dB, interp_80dB, ...
+    SampleRates=Fs, ...
+    FilterNames=["Interp_60dB", "Interp_80dB"], ...
+    Analysis="magnitude", OverlayAnalysis="phase");
+```
+
+### Example 3: Analyze Multistage Cascade Structure
+
+```matlab
+%% Visualize a multistage decimator cascade
+Fs = 44100;
+decCascade = designMultistageDecimator(16);
+
+% View overall response
+filterAnalyzer(decCascade, SampleRates=Fs, FilterNames="Multistage16x");
+
+% Check cascade structure
+info(decCascade)
+```
+
+### Supported Multirate Types
+
+| System Object | Created By | Filter Analyzer Support |
+|---------------|------------|------------------------|
+| `dsp.FIRDecimator` | `designMultirateFIR(..., SystemObject=true)` | ✓ Full support |
+| `dsp.FIRInterpolator` | `designMultirateFIR(..., SystemObject=true)` | ✓ Full support |
+| `dsp.FIRRateConverter` | `designMultirateFIR(..., SystemObject=true)` | ✓ Full support |
+| `dsp.FilterCascade` | `designMultistageDecimator()` | ✓ Full support |
+| `dsp.FilterCascade` | `designMultistageInterpolator()` | ✓ Full support |
+| `dsp.FilterCascade` | Manual cascade (see below) | ✓ Full support |
+
+### Example 4: Visualizing Multirate Pipelines (dec→filter→interp)
+
+When comparing multirate pipelines against single-stage filters, wrap the complete pipeline in `dsp.FilterCascade`:
+
+```matlab
+%% Compare FIR, IFIR, and Multirate Pipeline side-by-side
+Fs = 44100;
+M = 4;
+
+% Approach 1: Single-stage FIR
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3000, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+fir_sys = dsp.FIRFilter('Numerator', d_fir.Numerator);
+
+% Approach 2: IFIR
+Hf = fdesign.lowpass(2800/(Fs/2), 3000/(Fs/2), 0.1, 60);
+ifir_sys = ifir(Hf, 'SystemObject', true);
+
+% Approach 3: Multirate pipeline (dec → filter → interp)
+dec_sys = designMultirateFIR(DecimationFactor=M, StopbandAttenuation=60, SystemObject=true);
+d_core = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3000, ...
+    PassbandRipple=0.1, StopbandAttenuation=60, ...
+    SampleRate=Fs/M, DesignMethod="equiripple");
+core_sys = dsp.FIRFilter('Numerator', d_core.Numerator);  % Wrap for cascade
+interp_sys = designMultirateFIR(InterpolationFactor=M, StopbandAttenuation=60, SystemObject=true);
+
+% Create cascade from pipeline
+multirate_cascade = dsp.FilterCascade(dec_sys, core_sys, interp_sys);
+
+% Compare ALL THREE in Filter Analyzer
+fa = filterAnalyzer(fir_sys, ifir_sys, multirate_cascade, ...
+    FilterNames=["FIR_SingleStage", "IFIR_Cascade", "Multirate_Pipeline"], ...
+    SampleRates=Fs, Analysis="magnitude");
+
+% Add group delay for latency comparison
+addDisplays(fa, Analysis="groupdelay");
+showFilters(fa, true, FilterNames=["FIR_SingleStage", "IFIR_Cascade", "Multirate_Pipeline"]);
+
+% Compare MPIS
+fprintf('MPIS: FIR=%.0f, IFIR=%.0f, Multirate=%.0f\n', ...
+    cost(fir_sys).MultiplicationsPerInputSample, ...
+    cost(ifir_sys).MultiplicationsPerInputSample, ...
+    cost(multirate_cascade).MultiplicationsPerInputSample);
+```
+
+**Key points:**
+- Wrap `digitalFilter` in `dsp.FIRFilter` before adding to cascade
+- Use `dsp.FilterCascade(dec, filter, interp)` to create a single object
+- Filter Analyzer shows the **overall** frequency response of the cascade
+- Use same `SampleRates=Fs` for all (multirate rates are handled internally)
+
+---
+
+## Tips and Gotchas
+
+1. **Match FilterNames to variable names**: Use the same name as your workspace variable so you can easily identify filters. Example: `filterAnalyzer(d_butter, d_ellip, FilterNames=["d_butter", "d_ellip"])` — not `["Butterworth", "Elliptic"]`
+2. **Always store the handle**: Keep `fa` in your workspace to manage the session
+3. **Check validity**: Use `isvalid(fa)` before calling methods
+4. **Lost your handle?**: Use `fa = getFilterAnalyzerHandle` to recover it
+5. **Persist across sessions**: Use `saveSession(fa, 'myfilters.mat')` and load later
+6. **FilterNames must be valid MATLAB identifiers**: No spaces, hyphens, or special characters. Use underscores: `"d_butter"` not `"d-butter"` or `"d butter"`
+7. **Overlay rules are strict**: Frequency-domain only overlays with frequency-domain; time-domain with time-domain. `polezero`, `info`, `coefficients` don't support overlays.
+8. **Name-value syntax required**: Most methods use `DisplayNums=`, `FilterNames=` syntax, not positional arguments
+9. **Zoom presets**: `"passband"`, `"default"`, `"x"`, `"y"`, `"xy"` — custom axis limits require using the app UI
+10. **`filterAnalyzer` returns display number**: `[fa, dispNum] = filterAnalyzer(...)` — only the initial call returns both
+
+---
+
+## Version Info
+
+- `filterAnalyzer` function: **R2024a+**
+- `replaceFilters` method: **R2024a+**
+- `getAnalysisOptions` / `setAnalysisOptions`: **R2024a+**
+- `LegendStrings` argument: **R2025a+**
+- Tested on: **R2024b**

--- a/skills/matlab-digital-filter-design/knowledge/multirate.md
+++ b/skills/matlab-digital-filter-design/knowledge/multirate.md
@@ -1,0 +1,405 @@
+# Multirate Filtering Guide
+
+Complete guide for multirate filtering in MATLAB. Covers when to use each function, streaming vs offline workflows, and cost analysis.
+---
+
+## Table of Contents
+- [Critical Decision: Which Function to Use?](#critical-decision-which-function-to-use)
+- [When Not to Use designMultistageDecimator/Interpolator](#important-when-not-to-use-designmultistagedecimatorinterpolator)
+- [Concept: Multirate Pipeline](#concept-multirate-pipeline)
+- [Workflow 1: Streaming Multirate](#workflow-1-streaming-multirate-narrow-transition)
+- [Workflow 2: Offline Zero-Phase](#workflow-2-offline-zero-phase-narrow-transition)
+- [Workflow 3: Wideband Rate Conversion](#workflow-3-wideband-rate-conversion-large-m)
+- [Workflow 4: Complex Specifications](#workflow-4-complex-specifications-fdesign)
+- [Cost Analysis](#cost-analysis-how-to-compare-approaches)
+- [Key Functions Reference](#key-functions-reference)
+- [Gotchas](#gotchas)
+- [API References](#api-references)
+- [Visualization](#visualization)
+
+## Critical Decision: Which Function to Use?
+
+**The choice of multirate function depends on your use case.** Using the wrong function can result in 5× worse performance.
+
+### Quick Decision Table
+
+| Use Case | Recommended Approach | Why |
+|----------|---------------------|-----|
+| **Narrow transition + streaming** | `designMultirateFIR` + separate sharp filter | Relaxed anti-alias + efficient sharp filter at low rate |
+| **Narrow transition + offline** | `resample()` + sharp filter + `filtfilt()` | Simplest, built-in anti-alias, zero-phase |
+| **Wideband rate change (M≥8)** | `designMultistageDecimator/Interpolator` | Automatic cascade optimization |
+| **Complex frequency specs** | `fdesign.decimator` + `design()` | Flexible specification object |
+| **CIC or halfband filters** | `fdesign.decimator` with CIC response | Specialized filter types |
+
+---
+
+## IMPORTANT: When NOT to Use designMultistageDecimator/Interpolator
+
+**These functions are NOT optimal for narrow-transition filtering!**
+
+When you pass tight specs (narrow TW, high Astop), these functions try to achieve the sharp transition **within** the decimation/interpolation, requiring very long filters.
+
+### Real Example (Fs=44.1kHz, Fpass=2.8kHz, Fstop=3.1kHz, 60dB)
+
+| Approach | MPIS | Result |
+|----------|------|--------|
+| `designMultirateFIR` + sharp filter | **115.75** | BEST |
+| Single-stage FIR | 407.00 | Baseline |
+| `designMultistageDecimator` + `Interpolator` with tight specs | 531.25 | WORSE! |
+
+**Lesson**: For narrow transitions, use `designMultirateFIR` (relaxed anti-alias) + **separate sharp filter at reduced rate**.
+
+### When designMultistage* IS Optimal
+
+For **wideband rate conversion** (just anti-alias, no specific filtering), `designMultistageDecimator/Interpolator` with **default specs** is very efficient:
+
+| M | designMultirateFIR (MPIS) | designMultistage* (MPIS) | Winner |
+|---|---------------------------|--------------------------|--------|
+| 4 | 90.2 | **60.8** | Multistage |
+| 8 | 189.1 | **81.9** | Multistage (2.3×) |
+| 16 | 382.6 | **128.4** | Multistage (3.0×) |
+| 32 | 767.3 | **190.7** | Multistage (4.0×) |
+
+---
+
+## Concept: Multirate Pipeline
+
+```
+Input (Fs) → Decimate (÷M) → Filter (Fs/M) → Interpolate (×M) → Output (Fs)
+```
+
+**Why it works**: A 400-tap filter at 44.1 kHz becomes a ~100-tap filter at 11 kHz (after 4× decimation), and processes 1/4 as many samples.
+
+**Output rate = Input rate**: Decimation and interpolation cancel out.
+
+---
+
+## Workflow 1: Streaming Multirate (Narrow Transition)
+
+**Use `designMultirateFIR` for anti-alias + separate sharp filter.**
+
+```matlab
+%% Streaming multirate with narrow transition band
+Fs = 44100;
+Fpass = 2800; Fstop = 3100;
+Rp = 0.1; Rs = 60;
+M = 4;  % Decimation/interpolation factor
+Fs_dec = Fs / M;
+
+%% Design filters
+% Step 1: Decimator with RELAXED anti-alias (just prevent aliasing)
+dec = designMultirateFIR(DecimationFactor=M, ...
+    StopbandAttenuation=Rs, SystemObject=true);
+
+% Step 2: Sharp lowpass at reduced rate
+d_sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs_dec, DesignMethod="equiripple");
+
+% Step 3: Interpolator with anti-image
+interp = designMultirateFIR(InterpolationFactor=M, ...
+    StopbandAttenuation=Rs, SystemObject=true);
+
+%% Process frames (streaming)
+frameSize = 1024;  % Must be multiple of M
+y = zeros(size(x));
+
+for i = 1:frameSize:length(x)-frameSize+1
+    frame = x(i:i+frameSize-1);
+
+    % Pipeline: decimate → sharp filter → interpolate
+    frame_dec = dec(frame);
+    frame_filt = filter(d_sharp, frame_dec);  % Causal
+    frame_out = interp(frame_filt);
+
+    y(i:i+frameSize-1) = frame_out;
+end
+```
+
+**Note**: Streaming is **causal only** — no `filtfilt()`. There will be group delay.
+
+---
+
+## Workflow 2: Offline Zero-Phase (Narrow Transition)
+
+**Use `resample()` for simplicity — it has built-in anti-alias/anti-image filters.**
+
+```matlab
+%% Offline multirate with zero-phase sharp filter
+Fs = 44100;
+Fpass = 2800; Fstop = 3100;
+Rp = 0.1; Rs = 60;
+M = 4;
+Fs_dec = Fs / M;
+
+% Load signal
+[x, ~] = audioread("noisy_signal.wav");
+
+%% Stage 1: Decimate (resample handles anti-aliasing)
+x_dec = resample(x, 1, M);
+
+%% Stage 2: Sharp lowpass at reduced rate (zero-phase)
+d_sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs_dec, DesignMethod="equiripple");
+
+x_filt = filtfilt(d_sharp, x_dec);  % Zero-phase at low rate
+
+%% Stage 3: Interpolate back (resample handles anti-imaging)
+y = resample(x_filt, M, 1);
+
+% Output y is at original Fs, zero-phase filtered
+```
+
+**Advantages**:
+- Simple 3-line pipeline
+- `resample()` handles anti-alias/anti-image automatically
+- `filtfilt()` gives zero-phase at reduced computational cost
+
+---
+
+## Workflow 3: Wideband Rate Conversion (Large M)
+
+**Use `designMultistageDecimator/Interpolator` with DEFAULT specs for pure rate change.**
+
+```matlab
+%% Wideband rate conversion (M=16, no specific filtering)
+M = 16;
+Fs = 48000;
+
+% Default specs - optimized for wideband anti-alias
+dec = designMultistageDecimator(M);
+interp = designMultistageInterpolator(M);
+
+% View cascade structure
+info(dec)
+info(interp)
+
+% Cost comparison
+cost_dec = cost(dec);
+cost_interp = cost(interp);
+fprintf('Decimator: %.2f MPIS\n', cost_dec.MultiplicationsPerInputSample);
+fprintf('Interpolator: %.2f MPIS\n', cost_interp.MultiplicationsPerInputSample);
+
+% Apply (streaming)
+y_dec = dec(x);
+y_out = interp(y_dec);
+```
+
+**When to use**: Decimation factor M > 8, or when you want MATLAB to optimize the cascade automatically.
+
+---
+
+## Workflow 4: Complex Specifications (fdesign)
+
+**Use `fdesign.decimator` when you need specific passband/stopband control.**
+
+```matlab
+%% fdesign.decimator with lowpass specification
+M = 4;
+Fs = 44100;
+Fpass_norm = 2800 / Fs;  % Normalized to Fs
+Fstop_norm = 3100 / Fs;
+Rp = 0.1; Rs = 60;
+
+% Create specification object
+d = fdesign.decimator(M, 'lowpass', 'Fp,Fst,Ap,Ast', ...
+    Fpass_norm, Fstop_norm, Rp, Rs);
+
+% Available design methods
+designmethods(d)
+
+% Design with kaiserwin (handles tight specs)
+hd = design(d, 'kaiserwin', SystemObject=true);
+cost(hd)
+
+% Design with multistage (deprecated - use designMultistageDecimator)
+% hd_multi = design(d, 'multistage', SystemObject=true);
+```
+
+**Key points**:
+- Frequencies are normalized to Fs (0 to 1)
+- Use `'kaiserwin'` for tight specs where `'equiripple'` fails
+- The `'multistage'` method is deprecated — use `designMultistageDecimator` instead
+
+---
+
+## Cost Analysis: How to Compare Approaches
+
+### Using the cost() Function
+
+```matlab
+%% Measure MPIS for each component
+M = 4;
+Rs = 60;
+
+% Decimator
+dec = designMultirateFIR(DecimationFactor=M, ...
+    StopbandAttenuation=Rs, SystemObject=true);
+cost_dec = cost(dec);
+fprintf('Decimator: %d taps, %.2f MPIS\n', ...
+    length(dec.Numerator), cost_dec.MultiplicationsPerInputSample);
+
+% Sharp filter at reduced rate
+d_sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3100, ...
+    StopbandAttenuation=Rs, SampleRate=44100/M, ...
+    DesignMethod="equiripple");
+sharp_sys = dsp.FIRFilter(Numerator=d_sharp.Numerator);
+cost_sharp = cost(sharp_sys);
+fprintf('Sharp filter: %d taps, %.2f MPIS (at 1/%d rate = %.2f effective)\n', ...
+    length(d_sharp.Numerator), cost_sharp.MultiplicationsPerInputSample, ...
+    M, cost_sharp.MultiplicationsPerInputSample/M);
+
+% Interpolator
+interp = designMultirateFIR(InterpolationFactor=M, ...
+    StopbandAttenuation=Rs, SystemObject=true);
+cost_interp = cost(interp);
+fprintf('Interpolator: %d taps, %.2f MPIS\n', ...
+    length(interp.Numerator), cost_interp.MultiplicationsPerInputSample);
+
+% Total pipeline cost
+total_mpis = cost_dec.MultiplicationsPerInputSample + ...
+             cost_sharp.MultiplicationsPerInputSample/M + ...
+             cost_interp.MultiplicationsPerInputSample;
+fprintf('TOTAL: %.2f MPIS\n', total_mpis);
+```
+
+### Comparing with resample() Pipeline
+
+`resample()` has internal filters not exposed to `cost()`. Use `timeit()`:
+
+```matlab
+x = randn(44100*2, 1);  % 2 seconds at 44.1 kHz
+
+f_pipeline = @() resample(filtfilt(d_sharp, resample(x, 1, M)), M, 1);
+t_pipeline = timeit(f_pipeline);
+fprintf('Offline pipeline: %.2f ms\n', t_pipeline * 1000);
+```
+
+---
+
+## Key Functions Reference
+
+| Function | Use Case | Returns |
+|----------|----------|---------|
+| `designMultirateFIR()` | Single-stage decimator/interpolator | Coefficients or System object |
+| `designMultistageDecimator()` | Optimal cascaded decimator (large M, wideband) | `dsp.FilterCascade` |
+| `designMultistageInterpolator()` | Optimal cascaded interpolator (large M, wideband) | `dsp.FilterCascade` |
+| `resample(x, P, Q)` | Offline rate conversion with anti-alias | Resampled signal |
+| `fdesign.decimator()` | Flexible decimator specification | Specification object |
+| `fdesign.interpolator()` | Flexible interpolator specification | Specification object |
+| `dsp.FIRDecimator` | Streaming decimation System object | System object |
+| `dsp.FIRInterpolator` | Streaming interpolation System object | System object |
+
+---
+
+## Gotchas
+
+### 1. Don't Use designMultistage* with Tight Specs for Narrow Transitions
+
+```matlab
+% WRONG: Trying to do sharp filtering within decimation
+dec = designMultistageDecimator(M, Fs, TW, Rs);  % TW = narrow
+
+% RIGHT: Relaxed decimator + separate sharp filter
+dec = designMultirateFIR(DecimationFactor=M, ...);
+d_sharp = designfilt("lowpassfir", ..., SampleRate=Fs/M);
+```
+
+### 2. Don't Use System Objects with filtfilt()
+
+```matlab
+% WRONG: System objects have internal state
+dec_sys = designMultirateFIR(DecimationFactor=M, SystemObject=true);
+y = filtfilt(dec_sys, x);  % ERROR!
+
+% RIGHT: Use resample() for offline zero-phase
+x_dec = resample(x, 1, M);
+```
+
+### 3. Frame Size Must Be Multiple of M
+
+```matlab
+% For streaming decimation
+frameSize = 1024;  % OK for M=4 (1024/4 = 256)
+frameSize = 1000;  % ERROR for M=4 (not divisible)
+```
+
+### 4. resample() Has Hidden Filter Cost
+
+Don't claim "100 taps at 11 kHz" — `resample()` adds its own anti-alias/anti-image filtering. Measure total pipeline cost with `timeit()`.
+
+### 5. Fs Meaning Differs Between Functions
+
+- `designMultistageDecimator(M, Fs, ...)`: Fs = **input** rate
+- `designMultistageInterpolator(L, Fs, ...)`: Fs = **output** rate (R2024b+)
+
+---
+
+## API References
+
+| Doc File | Content |
+|----------|---------|
+| `docs/ref_designMultirateFIR.md` | Single-stage decimator/interpolator design |
+| `docs/ref_designMultistageDecimator.md` | Optimal cascaded decimator |
+| `docs/ref_designMultistageInterpolator.md` | Optimal cascaded interpolator |
+| `docs/ref_resample.md` | Offline sample rate conversion |
+| `docs/dsp_multirate-filtering.md` | Multirate concepts overview |
+
+---
+
+## Visualization
+
+**All multirate filters work with Filter Analyzer** for response visualization and comparison.
+
+### Visualizing Individual Multirate Filters
+
+```matlab
+% Compare decimator designs in Filter Analyzer
+dec4 = designMultirateFIR(DecimationFactor=4, SystemObject=true);
+decMulti = designMultistageDecimator(8);
+filterAnalyzer(dec4, decMulti, SampleRates=Fs, ...
+    FilterNames=["SingleStage", "Multistage"]);
+```
+
+### Visualizing Complete Multirate Pipelines
+
+**IMPORTANT**: For comparing dec→filter→interp pipelines against single-stage filters, wrap the complete pipeline in `dsp.FilterCascade`:
+
+```matlab
+%% Create cascade from multirate pipeline for Filter Analyzer
+Fs = 44100; M = 4;
+
+% Build pipeline components
+dec_sys = designMultirateFIR(DecimationFactor=M, StopbandAttenuation=60, SystemObject=true);
+d_core = designfilt("lowpassfir", ...
+    PassbandFrequency=2800, StopbandFrequency=3000, ...
+    StopbandAttenuation=60, SampleRate=Fs/M, DesignMethod="equiripple");
+core_sys = dsp.FIRFilter('Numerator', d_core.Numerator);  % Wrap digitalFilter!
+interp_sys = designMultirateFIR(InterpolationFactor=M, StopbandAttenuation=60, SystemObject=true);
+
+% Create cascade for visualization
+multirate_cascade = dsp.FilterCascade(dec_sys, core_sys, interp_sys);
+
+% Add to Filter Analyzer alongside other filter types
+filterAnalyzer(multirate_cascade, SampleRates=Fs, FilterNames="Multirate_Pipeline");
+```
+
+**Key points:**
+- Wrap `digitalFilter` in `dsp.FIRFilter` before adding to cascade
+- `dsp.FilterCascade` shows the **overall** response of the pipeline
+- Use same `SampleRates=Fs` as the input rate
+
+See `knowledge/filter-analyzer.md` → "Visualizing Multirate Pipelines" for complete comparison examples.
+
+---
+
+## See Also
+
+- `knowledge/efficient-filtering.md` — Decision guide for choosing approach
+- `knowledge/multistage-ifir.md` — IFIR (constant-rate alternative)
+- `knowledge/patterns.md` — Code templates
+- `knowledge/filter-analyzer.md` — Multirate filter visualization

--- a/skills/matlab-digital-filter-design/knowledge/multistage-ifir.md
+++ b/skills/matlab-digital-filter-design/knowledge/multistage-ifir.md
@@ -1,0 +1,288 @@
+# IFIR and Multistage Filtering Guide
+
+Complete guide for **Interpolated FIR (IFIR)** filters — a multistage approach that operates at **constant sample rate** (no decimation/interpolation).
+---
+
+## Table of Contents
+- [Concept](#concept)
+- [When to Use IFIR](#when-to-use-ifir)
+- [Key Functions](#key-functions)
+- [Workflow 1: SystemObject Method](#workflow-1-systemobject-method-filter-analyzer-compatible)
+- [Workflow 2: Raw Coefficients Method](#workflow-2-raw-coefficients-method-for-filtfilt)
+- [Understanding IFIR Structure](#understanding-ifir-structure)
+- [Cost Analysis](#cost-analysis)
+- [Comparison: IFIR vs Multirate](#comparison-ifir-vs-multirate)
+- [Choosing Interpolation Factor L](#choosing-interpolation-factor-l)
+- [Gotchas](#gotchas)
+- [API References](#api-references)
+- [See Also](#see-also)
+
+## Concept
+
+IFIR uses two filters in cascade:
+
+```
+Input → Model Filter h(z^L) → Image Suppressor g(z) → Output
+        (sparse)              (removes images)
+```
+
+- **Model filter `h(z^L)`**: Sparse filter with zeros inserted between taps (stretched by factor L)
+- **Image suppressor `g(z)`**: Removes spectral images created by the sparse filter
+- **Combined response**: Achieves the target narrowband response with fewer total multipliers
+
+**Key advantage**: Sample rate stays constant throughout — no decimation or interpolation needed.
+
+---
+
+## When to Use IFIR
+
+| Criterion | IFIR | Alternative |
+|-----------|------|-------------|
+| trans_pct < 2% | ✓ Good choice | Single-stage OK if > 5% |
+| Rate change problematic | ✓ **Best choice** | Multirate changes rate internally |
+| Need linear phase | ✓ Maintains linear phase | IIR loses linear phase |
+| Filter Analyzer visualization | ✓ Works with SystemObject=true | Multirate pipelines can't be visualized end-to-end |
+
+---
+
+## Key Functions
+
+| Function | Returns | Filter Analyzer? | filtfilt()? |
+|----------|---------|------------------|-------------|
+| `ifir(Hf, SystemObject=true)` | `dsp.FilterCascade` | ✓ Yes | ✗ Use object directly |
+| `ifir(L, 'low', freqs, devs)` | Raw coefficients `[b_ifir]` | ✗ No | ✓ Yes |
+| `design(Hf, 'ifir', SystemObject=true)` | `dsp.FilterCascade` | ✓ Yes | ✗ Use object directly |
+
+---
+
+## Workflow 1: SystemObject Method (Filter Analyzer Compatible)
+
+Use this when you want to visualize in Filter Analyzer or use streaming.
+
+```matlab
+%% IFIR with SystemObject (Filter Analyzer compatible)
+Fs = 44100;
+Fpass = 2800; Fstop = 3200;
+Rp = 0.1; Rs = 60;
+
+% Create filter specification (normalized frequencies)
+Fn = Fs / 2;
+Hf = fdesign.lowpass(Fpass/Fn, Fstop/Fn, Rp, Rs);
+
+% Design IFIR filter (returns dsp.FilterCascade)
+d_ifir = ifir(Hf, SystemObject=true);
+% Alternative: d_ifir = design(Hf, 'ifir', SystemObject=true);
+
+% View structure
+info(d_ifir)
+
+% Visualize in Filter Analyzer
+filterAnalyzer(d_ifir, FilterNames="IFIR_Lowpass", SampleRates=Fs, ...
+    Analysis="magnitude", OverlayAnalysis="phase");
+
+% Apply filter (streaming - causal)
+y = d_ifir(x);
+
+% For batch processing, reset between uses
+reset(d_ifir);
+```
+
+**Note**: `dsp.FilterCascade` objects work directly with Filter Analyzer but **cannot** be used with `filtfilt()`.
+
+---
+
+## Workflow 2: Raw Coefficients Method (For filtfilt)
+
+Use this when you need zero-phase filtering with `filtfilt()`.
+
+```matlab
+%% IFIR with raw coefficients (for filtfilt)
+Fs = 44100;
+Fpass = 2800; Fstop = 3200;
+Rp = 0.1; Rs = 60;
+Fn = Fs / 2;
+
+% Calculate deviations from ripple specs
+dev_pass = (10^(Rp/20) - 1) / (10^(Rp/20) + 1);
+dev_stop = 10^(-Rs/20);
+
+% Choose interpolation factor L (typically 2-8)
+L = 4;  % Higher L = more sparse model filter
+
+% Design IFIR (returns coefficient vectors)
+[b_ifir, b_model, b_image] = ifir(L, 'low', [Fpass Fstop]/Fn, [dev_pass dev_stop]);
+
+% Apply with filtfilt (zero-phase)
+y = filtfilt(b_ifir, 1, x);
+
+% Report filter lengths
+fprintf('Combined IFIR: %d taps\n', length(b_ifir));
+fprintf('Model filter:  %d taps (sparse)\n', length(b_model));
+fprintf('Image suppressor: %d taps\n', length(b_image));
+```
+
+**Note**: Raw coefficients work with `filtfilt()` but cannot be added directly to Filter Analyzer.
+
+---
+
+## Understanding IFIR Structure
+
+### Model Filter h(z^L)
+
+The model filter is "stretched" by inserting L-1 zeros between each coefficient:
+
+```
+Original:  h = [h0, h1, h2, h3]
+Stretched: h(z^4) = [h0, 0, 0, 0, h1, 0, 0, 0, h2, 0, 0, 0, h3]
+```
+
+This creates a narrower transition band but introduces spectral images.
+
+### Image Suppressor g(z)
+
+A short lowpass filter that removes the images created by the sparse model filter.
+
+### Why It's Efficient
+
+| Component | Taps | Non-zero Multiplies |
+|-----------|------|---------------------|
+| Model filter h(z^L) | ~400 (sparse) | ~100 (only every L-th) |
+| Image suppressor g(z) | ~30 | ~30 |
+| **Total** | ~430 | **~130** |
+
+Compare to single-stage FIR: 400 taps = 400 multiplies.
+
+---
+
+## Cost Analysis
+
+### Measuring MPIS for IFIR
+
+```matlab
+%% Get MPIS for IFIR SystemObject
+Fs = 44100;
+Fpass = 2800; Fstop = 3200;
+Rp = 0.1; Rs = 60;
+Fn = Fs / 2;
+
+Hf = fdesign.lowpass(Fpass/Fn, Fstop/Fn, Rp, Rs);
+d_ifir = ifir(Hf, SystemObject=true);
+
+% Get cost
+c = cost(d_ifir);
+fprintf('IFIR MPIS: %.2f\n', c.MultiplicationsPerInputSample);
+fprintf('Coefficients: %d\n', c.NumCoefficients);
+```
+
+### Comparison with Alternatives
+
+```matlab
+%% Compare IFIR vs single-stage vs IIR
+% Single-stage FIR
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    StopbandAttenuation=Rs, SampleRate=Fs, DesignMethod="equiripple");
+fir_sys = dsp.FIRFilter('Numerator', d_fir.Numerator);
+
+% IIR Elliptic
+d_iir = designfilt("lowpassiir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    StopbandAttenuation=Rs, SampleRate=Fs, DesignMethod="ellip");
+iir_sys = dsp.SOSFilter('Numerator', d_iir.Numerator, 'Denominator', d_iir.Denominator);
+
+% Compare
+fprintf('Single-stage FIR: %.0f MPIS\n', cost(fir_sys).MultiplicationsPerInputSample);
+fprintf('IFIR:             %.0f MPIS\n', cost(d_ifir).MultiplicationsPerInputSample);
+fprintf('IIR Elliptic:     %.0f MPIS\n', cost(iir_sys).MultiplicationsPerInputSample);
+```
+
+---
+
+## Comparison: IFIR vs Multirate
+
+| Aspect | IFIR | Multirate |
+|--------|------|-----------|
+| **Sample rate** | Constant throughout | Changes internally |
+| **Structure** | Two filters in cascade | Decimate→filter→interpolate pipeline |
+| **Filter Analyzer** | ✓ Works directly | ✗ Can't show end-to-end |
+| **Zero-phase offline** | Raw coefficients + filtfilt | resample + filtfilt |
+| **Complexity** | Simpler (one cascade) | More stages |
+| **Best for** | Rate change problematic | Large decimation possible |
+
+---
+
+## Choosing Interpolation Factor L
+
+The interpolation factor L controls the trade-off between model filter sparsity and image suppressor length:
+
+| L | Model Filter | Image Suppressor | Total Efficiency |
+|---|--------------|------------------|------------------|
+| 2 | Less sparse | Shorter | Moderate |
+| 4 | More sparse | Medium | Good |
+| 8 | Very sparse | Longer | Diminishing returns |
+
+**Rule of thumb**: Start with L=4, adjust based on cost() measurements.
+
+```matlab
+% Compare different L values
+for L = [2 4 6 8]
+    [b_ifir, ~, ~] = ifir(L, 'low', [Fpass Fstop]/Fn, [dev_pass dev_stop]);
+    fprintf('L=%d: %d total taps\n', L, length(b_ifir));
+end
+```
+
+---
+
+## Gotchas
+
+### 1. SystemObject vs Raw Coefficients
+
+```matlab
+% SystemObject: Can't use with filtfilt
+d_ifir = ifir(Hf, SystemObject=true);
+y = filtfilt(d_ifir, x);  % ERROR!
+
+% Raw coefficients: Can't use with Filter Analyzer
+[b_ifir, ~, ~] = ifir(L, 'low', freqs, devs);
+filterAnalyzer(b_ifir, ...);  % Won't show IFIR structure properly
+```
+
+### 2. Normalized Frequencies for fdesign
+
+```matlab
+% fdesign uses normalized frequencies (0 to 1, where 1 = Fs/2)
+Fn = Fs / 2;
+Hf = fdesign.lowpass(Fpass/Fn, Fstop/Fn, Rp, Rs);  % Normalized!
+
+% NOT: fdesign.lowpass(Fpass, Fstop, ...)  % Wrong!
+```
+
+### 3. Deviations vs dB for Raw ifir()
+
+```matlab
+% Raw ifir() uses linear deviations, not dB
+Rp_dB = 0.1;  % Passband ripple in dB
+Rs_dB = 60;   % Stopband attenuation in dB
+
+dev_pass = (10^(Rp_dB/20) - 1) / (10^(Rp_dB/20) + 1);  % Convert to deviation
+dev_stop = 10^(-Rs_dB/20);  % Convert to deviation
+
+[b_ifir, ~, ~] = ifir(L, 'low', freqs, [dev_pass dev_stop]);
+```
+
+---
+
+## API References
+
+| Doc File | Content |
+|----------|---------|
+| `docs/ref_ifir.md` | `ifir()` function reference |
+
+---
+
+## See Also
+
+- `knowledge/efficient-filtering.md` — Decision guide for choosing approach
+- `knowledge/multirate.md` — Multirate (rate-changing) alternative
+- `knowledge/patterns.md` — Code templates
+- `knowledge/filter-analyzer.md` — Visualizing IFIR filters

--- a/skills/matlab-digital-filter-design/knowledge/patterns.md
+++ b/skills/matlab-digital-filter-design/knowledge/patterns.md
@@ -1,0 +1,523 @@
+# Filter Design Patterns
+
+Quick design templates and application patterns for MATLAB digital filter design. Consult this file when you need ready-to-use code patterns.
+
+---
+## Table of Contents
+- [Quick Design Patterns](#quick-design-patterns)
+  - [High-Level One-Liners](#high-level-one-liners)
+  - [Order Estimation](#order-estimation)
+  - [Minimum-Phase FIR (Reduced Latency)](#minimum-phase-fir-reduced-latency)
+  - [IFIR (Interpolated FIR) for Narrow Transitions](#ifir-interpolated-fir-for-narrow-transitions)
+- [Multirate Design Patterns](#multirate-design-patterns)
+  - [Streaming Multirate](#streaming-multirate-modern-syntax-r2024a)
+  - [Offline Zero-Phase Multirate](#offline-zero-phase-multirate)
+  - [Wideband Rate Conversion](#wideband-rate-conversion-large-m)
+- [Application Patterns](#application-patterns)
+  - [Extract Coefficients](#extract-coefficients-from-digitalfilter-object)
+  - [Offline Validation](#offline-validation-zero-phase)
+  - [Streaming CTF](#streaming-ctf-path-r2024b)
+  - [Streaming SOS System Object](#streaming-sos-system-object-all-versions)
+  - [Advanced Filter Analyzer Usage](#advanced-filter-analyzer-usage)
+- [Complete Examples](#complete-examples)
+- [Quick Lookup](#quick-lookup)
+
+**Note**: For basic `designfilt()` syntax (response types, parameters, gotchas), see `cards/designfilt.md`.
+
+
+## Quick Design Patterns
+
+### High-Level One-Liners
+
+These functions auto-design minimum-order filters and return `[y, d]`:
+
+```matlab
+% Lowpass / Highpass
+[y, d] = lowpass(x, Fpass, Fs, StopbandAttenuation=Rs, ImpulseResponse="iir");
+[y, d] = highpass(x, Fpass, Fs, StopbandAttenuation=Rs, ImpulseResponse="iir");
+
+% Bandpass / Bandstop (passband as [f1 f2])
+[y, d] = bandpass(x, [f1 f2], Fs, StopbandAttenuation=Rs, ImpulseResponse="iir");
+[y, d] = bandstop(x, [f1 f2], Fs, StopbandAttenuation=Rs, ImpulseResponse="iir");
+```
+
+**Note**: Set `ImpulseResponse="fir"` for linear phase. Use `Steepness` parameter (0-1) to control transition width.
+
+---
+
+### Order Estimation
+
+Use MATLAB-native estimators to sanity-check how big a single-stage FIR might be **before** committing to multirate/IFIR.
+
+```matlab
+% Convert dB specs to linear deviations
+dev_p = (10^(Rp_dB/20)-1) / (10^(Rp_dB/20)+1);
+dev_s = 10^(-Rs_dB/20);
+
+% LOWPASS example (Hz). Adapt f/a for highpass/bandpass/bandstop.
+f = [Fpass Fstop];
+a = [1 0];
+dev = [dev_p dev_s];
+
+% Kaiser window estimate
+[N_kaiser, Wn, beta, ftype] = kaiserord(f, a, dev, Fs);
+
+% Equiripple estimate (Parks–McClellan)
+[N_pm, fo, ao, w] = firpmord(f, a, dev, Fs);
+
+fprintf("Estimated order: Kaiser=%d, Equiripple=%d\n", N_kaiser, N_pm);
+```
+
+
+### Minimum-Phase FIR (Reduced Latency)
+
+Use `PhaseConstraint="minimum"` with designfilt (**NOT** `MinimumPhase=true`):
+
+```matlab
+% Minimum-phase FIR (lower delay than linear phase, same order)
+d = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="equiripple", ...
+    PhaseConstraint="minimum");  % CORRECT syntax
+
+% Alternative: firgr with 'minphase' flag (advanced)
+b = firgr(N, [0 Fp/Fn Fst/Fn 1], [1 1 0 0], [1 w], 'minphase');
+```
+
+**Trade-offs**:
+- Lower group delay than linear-phase (roughly half)
+- Non-linear phase (not suitable for phase-sensitive applications)
+- Cannot use `filtfilt()` (already minimum phase, would create mixed-phase result)
+- Use `filter()` for causal application
+
+---
+
+### IFIR (Interpolated FIR) for Narrow Transitions
+
+For narrow transition bands (trans_pct < 2%; see `cards/efficient-filtering.md`), IFIR reduces total multipliers by using sparse filter + image suppressor at constant sample rate.
+
+**Method 1: fdesign + ifir with SystemObject (Recommended for Filter Analyzer)**
+
+```matlab
+% Design IFIR lowpass with fdesign (returns dsp.FilterCascade)
+Fpass = 2800; Fstop = 3200; Fs = 44100;
+
+Hf = fdesign.lowpass(Fpass/(Fs/2), Fstop/(Fs/2));
+
+% Two equivalent ways to get dsp.FilterCascade:
+d_ifir = ifir(Hf, SystemObject=true);           % Option 1
+% d_ifir = design(Hf, 'ifir', SystemObject=true);  % Option 2
+
+% Works directly with Filter Analyzer
+filterAnalyzer(d_ifir, FilterNames="IFIR_Lowpass", SampleRates=Fs);
+
+% Apply filter (streaming)
+y = d_ifir(x);
+
+% For offline zero-phase, use Method 2 (raw coefficients with filtfilt)
+```
+
+**Method 2: Raw ifir() function (For coefficient access and filtfilt)**
+
+```matlab
+% Raw IFIR design returns coefficient arrays
+Fn = Fs/2;
+dev_pass = (10^(Rp/20) - 1) / (10^(Rp/20) + 1);
+dev_stop = 10^(-Rs/20);
+
+[b_ifir, b_model, b_image] = ifir(L, "low", [Fpass Fstop]/Fn, [dev_pass dev_stop]);
+
+% Apply with filtfilt (works with raw coefficients)
+y = filtfilt(b_ifir, 1, x);
+
+% WARNING: Raw coefficients don't work directly with filterAnalyzer()
+% Use Method 1 for Filter Analyzer compatibility
+```
+
+**When to use IFIR**:
+- Narrow transition bands (trans_pct < 2%; see `cards/efficient-filtering.md`)
+- Constant sample rate required (can't use multirate)
+- Need fewer multipliers than single-stage FIR
+
+**Trade-offs vs Multirate**:
+- IFIR: Constant rate, simpler pipeline, works with Filter Analyzer (Method 1)
+- Multirate: May be faster for very narrow bands, but internal rate change
+
+---
+
+## Multirate Design Patterns
+
+### Streaming Multirate (Modern Syntax, R2024a+)
+
+For real-time/streaming applications with polyphase efficiency:
+
+```matlab
+% Example: Multistage lowpass (STREAMING/REAL-TIME)
+M = 4;  % Decimation factor
+Fs_dec = Fs / M;  % Decimated sample rate
+
+% Stage 1: Anti-alias + decimate (modern syntax with SystemObject=true)
+dec_filt = designMultirateFIR(DecimationFactor=M, ...
+    StopbandAttenuation=Rs, SystemObject=true);
+
+% Stage 2: Sharp lowpass at reduced rate
+d_sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs_dec, DesignMethod="equiripple");
+
+% Stage 3: Interpolate + image rejection (modern syntax)
+interp_filt = designMultirateFIR(InterpolationFactor=M, ...
+    StopbandAttenuation=Rs, SystemObject=true);
+
+% Apply cascade (STREAMING - causal, has group delay)
+x_dec = dec_filt(x);             % Decimate
+x_filt = filter(d_sharp, x_dec); % Sharp filter at low rate (causal)
+y = interp_filt(x_filt);         % Interpolate back to original Fs
+```
+
+### Offline Zero-Phase Multirate
+
+For offline batch processing where zero-phase filtering is needed:
+
+```matlab
+% Example: Multistage lowpass (OFFLINE - zero-phase)
+M = 4;
+Fs_dec = Fs / M;
+
+% Stage 1: Decimate with built-in anti-alias (use resample, NOT System objects)
+x_dec = resample(x, 1, M);
+
+% Stage 2: Sharp lowpass at reduced rate (zero-phase)
+d_sharp = designfilt("lowpassfir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs_dec, DesignMethod="equiripple");
+
+x_filt = filtfilt(d_sharp, x_dec);  % Zero-phase filtering
+
+% Stage 3: Interpolate back (use resample for proper alignment)
+y = resample(x_filt, M, 1);
+```
+
+**WARNING**: Do NOT use `dsp.FIRDecimator`/`FIRInterpolator` with `filtfilt()`. See `cards/multirate-offline.md` for details.
+
+### Wideband Rate Conversion (Large M)
+
+For pure rate conversion with large factors (M≥8), use `designMultistageDecimator/Interpolator`:
+
+```matlab
+% Wideband rate conversion - multistage automatically optimizes cascade
+M = 16;  % Large decimation factor
+
+% Multistage decimator (default wideband TW)
+dec = designMultistageDecimator(M);
+
+% Multistage interpolator (default wideband TW)
+interp = designMultistageInterpolator(M);
+
+% View cascade structure and cost
+info(dec)
+cost(dec)
+
+% Apply (streaming)
+y_dec = dec(x);
+y_out = interp(y_dec);
+```
+
+**Note**: These functions automatically factor composite M into stages for minimum MPIS. Benefits increase with M. Default TW is wideband; for narrow-transition filtering, use the streaming/offline patterns above instead.
+
+---
+
+## Application Patterns
+
+### Extract Coefficients from digitalFilter Object
+
+```matlab
+% After designing with designfilt()
+d = designfilt("lowpassiir", ...);
+
+% Get CTF form (per-section rows)
+B = d.Numerator;      % Lx3 [b0 b1 b2] for each section
+A = d.Denominator;    % Lx3 [a0 a1 a2] for each section
+L = size(B, 1);       % number of biquad sections
+
+% Convert to SOS matrix (Lx6) if needed
+sos = [B A];          % [b0 b1 b2 a0 a1 a2] per row
+
+% DEPRECATED: Don't use d.Coefficients (removed in recent versions)
+```
+
+### Offline Validation (Zero-Phase)
+
+```matlab
+% Zero-phase reference (doubles effective filter order)
+y0 = filtfilt(d, x);
+
+% Frequency response (Hz-aware)
+figure;
+freqz(d, [], Fs);
+grid on;
+title('Magnitude & Phase Response');
+
+% Group delay
+figure;
+grpdelay(d, [], Fs);
+grid on;
+title('Group Delay vs Frequency');
+
+% Measure achieved specs
+[h, f] = freqz(d, 2048, Fs);
+mag_dB = 20*log10(abs(h));
+
+% Find -3dB cutoff
+idx_3dB = find(mag_dB < -3, 1);
+fprintf('-3dB Cutoff: %.2f Hz\n', f(idx_3dB));
+
+% Measure stopband attenuation
+stopband_idx = f > Fstop;
+min_atten = -max(mag_dB(stopband_idx));
+fprintf('Stopband Attenuation: %.1f dB\n', min_atten);
+```
+
+### Streaming: CTF Path (R2024b+)
+
+```matlab
+% Extract CTF coefficients
+B = d.Numerator;
+A = d.Denominator;
+
+% ONE-SHOT: Process entire signal (no frame management)
+y_all = ctffilt(B, A, x);
+
+% FRAME-BY-FRAME: Real-time with state carryover
+frameLen = 1024;
+state_ctf = [];  % initialize empty (zeros internally)
+N = numel(x);
+y_frames = zeros(N, 1);
+p = 1;
+
+while p <= N
+    q = min(p + frameLen - 1, N);
+    [y_frames(p:q), state_ctf] = ctffilt(B, A, x(p:q), state_ctf);
+    p = q + 1;
+end
+
+% Verify: y_all ≈ y_frames (within numerical precision)
+max_error = max(abs(y_all - y_frames));
+fprintf('Max streaming error: %.2e\n', max_error);
+```
+
+### Streaming: SOS System Object (All Versions)
+
+**PREFERRED METHOD**: Use `SystemObject=true` in `designfilt()`:
+
+```matlab
+% Get dsp.SOSFilter directly (no manual coefficient extraction)
+sosFilter = designfilt("lowpassiir", ...
+    PassbandFrequency=Fpass, StopbandFrequency=Fstop, ...
+    PassbandRipple=Rp, StopbandAttenuation=Rs, ...
+    SampleRate=Fs, DesignMethod="ellip", ...
+    SystemObject=true);  % Returns dsp.SOSFilter with ScaleValues
+
+% Access properties if needed
+if sosFilter.HasScaleValues
+    G = sosFilter.ScaleValues;  % Section scale values
+end
+
+% ONE-SHOT
+y_all = sosFilter(x);
+
+% FRAME-BY-FRAME (state preserved automatically)
+reset(sosFilter);  % ensure known start
+frameLen = 1024;
+p = 1;
+y_frames = zeros(numel(x), 1);
+
+while p <= numel(x)
+    q = min(p + frameLen - 1, numel(x));
+    y_frames(p:q) = sosFilter(x(p:q));  % state handled internally
+    p = q + 1;
+end
+
+% Works for codegen, Simulink, and HDL workflows
+```
+
+**ALTERNATIVE**: Manual creation from existing `digitalFilter`:
+
+```matlab
+% If you already have a digitalFilter object 'd'
+B = d.Numerator;
+A = d.Denominator;
+sosFilt = dsp.SOSFilter('Numerator', B, 'Denominator', A);
+y = sosFilt(x);
+```
+
+### Advanced Filter Analyzer Usage
+
+```matlab
+Fs = 44100;
+
+% Design two filters for comparison
+hpIIR = designfilt("highpassiir", ...
+    StopbandFrequency=200, PassbandFrequency=300, ...
+    StopbandAttenuation=60, PassbandRipple=1, ...
+    SampleRate=Fs, DesignMethod="ellip");
+
+hpFIR = designfilt("highpassfir", ...
+    StopbandFrequency=200, PassbandFrequency=300, ...
+    StopbandAttenuation=70, PassbandRipple=0.5, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+% Configure frequency-domain display
+optsMag = filterAnalysisOptions("magnitude", "phase", ...
+    FrequencyNormalizationMode="unnormalized", ...
+    ReferenceSampleRateMode="specify", ...
+    ReferenceSampleRate=Fs, ...
+    FrequencyRange="onesided", ...
+    FrequencyScale="log", ...
+    NFFT=4096, ...
+    NormalizeMagnitude=true);
+
+% IMPORTANT: FilterNames must be valid MATLAB identifiers
+filterNames = ["HP_IIR_ellip", "HP_FIR_equiripple"];
+
+[fa, disp1] = filterAnalyzer(hpIIR, hpFIR, ...
+    FilterNames=filterNames, ...
+    SampleRates=[Fs Fs], ...
+    AnalysisOptions=optsMag);
+
+% Add time-domain displays (impulse + step)
+optsTD = filterAnalysisOptions("impulse", "step", ...
+    ResponseLengthMode="specify", ...
+    ResponseLength=512);
+disp2 = addDisplays(fa, ...
+    AnalysisOptions=optsTD, ...
+    FilterNames=filterNames);
+```
+
+---
+
+## Complete Examples
+
+### Example 1: Minimal Lowpass (Auto Min-Order, Offline Zero-Phase)
+
+**User Request**: "Design a lowpass filter at 48 kHz, pass 8 kHz, stop 10 kHz, 80 dB attenuation, zero-phase offline"
+
+```matlab
+Fs = 48e3;
+
+% High-level one-liner (auto designs minimum order IIR)
+[y, d] = lowpass(x, 8e3, Fs, ...
+    StopbandAttenuation=80, ...
+    ImpulseResponse="iir", ...
+    Steepness=0.85);
+
+% Zero-phase reference (offline processing)
+y0 = filtfilt(d, x);
+
+% Validate response (Hz-aware)
+figure; freqz(d, [], Fs); grid on;
+title('Lowpass IIR: |H(f)| & Phase');
+
+figure; grpdelay(d, [], Fs); grid on;
+title('Lowpass IIR: Group Delay');
+
+% Report specs
+fprintf('Filter Order: %d\n', filtord(d));
+[h, f] = freqz(d, 512, Fs);
+fprintf('-3dB Cutoff: %.1f Hz\n', f(find(abs(h) < 1/sqrt(2), 1)));
+```
+
+### Example 2: Speech Bandpass (IIR with Streaming)
+
+**User Request**: "Bandpass filter for speech (300-3400 Hz) at 44.1 kHz, 1 dB passband ripple, 60 dB stopband, real-time causal"
+
+```matlab
+Fs = 44100;
+
+% Design IIR bandpass (IMPORTANT: use scalar edge properties with 1/2 suffixes!)
+d = designfilt("bandpassiir", ...
+    StopbandFrequency1=200,  PassbandFrequency1=300, ...
+    PassbandFrequency2=3400, StopbandFrequency2=3900, ...
+    PassbandRipple=1, ...
+    StopbandAttenuation1=60, StopbandAttenuation2=60, ...
+    SampleRate=Fs, DesignMethod="ellip");
+
+% Streaming: dsp.SOSFilter via SystemObject flag (PREFERRED)
+sosFilter = designfilt("bandpassiir", ...
+    StopbandFrequency1=200,  PassbandFrequency1=300, ...
+    PassbandFrequency2=3400, StopbandFrequency2=3900, ...
+    PassbandRipple=1, ...
+    StopbandAttenuation1=60, StopbandAttenuation2=60, ...
+    SampleRate=Fs, DesignMethod="ellip", ...
+    SystemObject=true);  % Returns dsp.SOSFilter directly
+
+y_sos = sosFilter(x);  % Use directly
+
+% Offline zero-phase validation
+y0 = filtfilt(d, x);
+figure; freqz(d, [], Fs); grid on;
+
+fprintf('Filter Order: %d sections\n', size(d.Numerator, 1));
+```
+
+### Example 3: Linear-Phase FIR with Filter Analyzer Overlay
+
+**User Request**: "Linear-phase FIR lowpass at 10 kHz, pass 1 kHz, stop 1.2 kHz, 70 dB attenuation. Compare with IIR."
+
+```matlab
+Fs = 1e4;
+
+% FIR design (linear phase, equiripple)
+d_fir = designfilt("lowpassfir", ...
+    PassbandFrequency=1e3, StopbandFrequency=1.2e3, ...
+    PassbandRipple=0.2, StopbandAttenuation=70, ...
+    SampleRate=Fs, DesignMethod="equiripple");
+
+% IIR comparator (elliptic, minimum order)
+d_iir = designfilt("lowpassiir", ...
+    PassbandFrequency=1e3, StopbandFrequency=1.2e3, ...
+    PassbandRipple=0.2, StopbandAttenuation=70, ...
+    SampleRate=Fs, DesignMethod="ellip");
+
+% Apply FIR with zero-phase
+y0 = filtfilt(d_fir, x);
+
+% Overlay comparison in Filter Analyzer
+% IMPORTANT: FilterNames must be valid MATLAB identifiers!
+fa = filterAnalyzer(d_fir, d_iir, ...
+    FilterNames=["FIR_equiripple", "IIR_ellip"], ...
+    Analysis="magnitude", ...
+    OverlayAnalysis="phase", ...
+    SampleRates=[Fs Fs]);
+
+% Report
+fprintf('FIR Length: %d taps\n', length(d_fir.Numerator));
+fprintf('IIR Order: %d sections\n', size(d_iir.Numerator, 1));
+fprintf('FIR Group Delay: %.2f samples\n', mean(grpdelay(d_fir, 1)));
+```
+
+**Trade-offs**:
+- FIR: Linear phase, ~120 taps
+- IIR: Minimum order (4-6 sections), non-linear phase
+- FIR suitable for offline; IIR better for real-time
+
+---
+
+## Quick Lookup
+
+| Pattern | Section | Use Case |
+|---------|---------|----------|
+| High-level one-liners | Quick Design | Rapid prototyping |
+| FIR designfilt | Quick Design | Linear phase filters |
+| IIR designfilt | Quick Design | Sharp cutoff, minimum order |
+| Minimum-phase FIR | Quick Design | Reduced latency |
+| Streaming multirate | Multirate | Real-time polyphase |
+| Offline multirate | Multirate | Zero-phase with `resample()` |
+| Coefficient extraction | Application | Manual coefficient access |
+| CTF streaming | Application | R2024b+ real-time |
+| SOS streaming | Application | All versions real-time |
+| Filter Analyzer | Application | Visual comparison |
+


### PR DESCRIPTION
Adds a skill for designing and validating digital filters in MATLAB (Signal Processing Toolbox + DSP System Toolbox).

### Features
- Guided spec collection (sample rate, edges, mode, phase constraints)
- Automatic architecture recommendations based on transition bandwidth
- Knowledge cards covering key functions and design patterns
- Built-in verification workflow with Filter Analyzer

### Use cases
- Cleaning up noisy signals
- Real-time streaming or offline batch filtering

### Testing

- Tested locally with Claude Code for a set of use cases.