### PR TITLE
Added marketplace.json to install the plugin directly from claude code CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "name": "matlab-skills",
+  "owner": {
+    "name": "The MathWorks, Inc."
+  },
+  "metadata": {
+    "description": "MATLAB skills for Claude Code - Live Scripts, testing, performance optimization, uihtml apps, and digital filter design"
+  },
+  "plugins": [
+    {
+      "name": "matlab-skills",
+      "source": "./",
+      "description": "A collection of Claude skills for MATLAB development, including Live Script generation, unit testing, performance optimization, and HTML/JavaScript app building.",
+      "version": "1.0.0",
+      "author": {
+        "name": "The MathWorks, Inc."
+      },
+      "homepage": "https://github.com/matlab/skills",
+      "repository": "https://github.com/matlab/skills",
+      "license": "BSD-3-Clause",
+      "keywords": [
+        "matlab",
+        "live-scripts",
+        "testing",
+        "performance",
+        "optimization",
+        "uihtml",
+        "digital-filter"
+      ],
+      "category": "development"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -93,10 +93,14 @@ Designs and validates digital filters in MATLAB using Signal Processing Toolbox 
 
 ### Claude Code (CLI)
 
-**Recommended**: Install all skills together as a plugin:
+**Recommended**: Install via the plugin marketplace:
 
 ```bash
-/plugin install github:matlab/skills
+# Add the marketplace
+/plugin marketplace add matlab/skills
+
+# Install the plugin
+/plugin install matlab-skills@matlab-skills
 ```
 
 This installs all MATLAB skills (`matlab-live-script`, `matlab-test-generator`, `matlab-performance-optimizer`, `matlab-uihtml-app-builder`, `matlab-digital-filter-design`) in one command. Skills automatically activate when Claude detects relevant tasks.
@@ -203,10 +207,10 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 
 ## Skill Development Resources
 
-- [Official Skills Documentation](https://docs.claude.com/en/docs/claude-code/skills)
+- [Official Skills Documentation](https://code.claude.com/docs/en/skills)
 - [Agent Skills Specification](https://github.com/anthropics/skills/blob/main/agent_skills_spec.md)
 - [Anthropic Skills Repository](https://github.com/anthropics/skills)
-- [Claude Code Plugin Guide](https://docs.claude.com/en/docs/claude-code/plugins)
+- [Claude Code Plugin Guide](https://code.claude.com/docs/en/plugins)
 
 ## Related Projects
 


### PR DESCRIPTION
The recommended way to install the skills in the README.md resulted in an error. At least for me in the latest claude code cli (2.1.20). 

```bash
/plugin install github:matlab/skills
  ⎿  Marketplace "github:matlab/skills" not found
```

The solution is to add a marketplace.json and then add the skills from that marketplace. That would result in a working `/plugin` install as follows
```bash
# Add the marketplace
/plugin marketplace add matlab/skills

# Install the plugin
/plugin install matlab-skills@matlab-skills
```